### PR TITLE
feat: make backend port configurable

### DIFF
--- a/addon/backend/cmd/server/main.go
+++ b/addon/backend/cmd/server/main.go
@@ -1,25 +1,48 @@
 package main
 
 import (
-    "database/sql"
-    "log"
-    "net/http"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
 
-    _ "modernc.org/sqlite"
+	_ "modernc.org/sqlite"
 )
 
-func main() {
-    db, err := sql.Open("sqlite", "data.db")
-    if err != nil {
-        log.Fatalf("failed to open database: %v", err)
-    }
-    defer db.Close()
-
-    http.HandleFunc("/api/hello", func(w http.ResponseWriter, r *http.Request) {
-        w.Write([]byte("Hello from DT3D backend"))
-    })
-
-    log.Println("Listening on :8080")
-    log.Fatal(http.ListenAndServe(":8080", nil))
+type options struct {
+	Port int `json:"port"`
 }
 
+func loadPort() int {
+	port := 8080
+	data, err := os.ReadFile("/data/options.json")
+	if err != nil {
+		return port
+	}
+	var opt options
+	if err := json.Unmarshal(data, &opt); err != nil {
+		return port
+	}
+	if opt.Port != 0 {
+		port = opt.Port
+	}
+	return port
+}
+
+func main() {
+	port := loadPort()
+	db, err := sql.Open("sqlite", "data.db")
+	if err != nil {
+		log.Fatalf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	http.HandleFunc("/api/hello", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello from DT3D backend"))
+	})
+
+	log.Printf("Listening on :%d", port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+}

--- a/addon/config.yaml
+++ b/addon/config.yaml
@@ -10,5 +10,7 @@ startup: services
 boot: auto
 ports:
   8080/tcp: 8080
-options: {}
-schema: {}
+options:
+  port: 8080
+schema:
+  port: int?

--- a/frontend/dist/dt3d-card.js
+++ b/frontend/dist/dt3d-card.js
@@ -18948,16 +18948,47 @@ class Wu extends HTMLElement {
     this.hassInstance = e;
   }
   connectedCallback() {
-    const e = this.config?.width || 200, t = this.config?.height || 200, n = document.createElement("div");
-    n.style.width = `${e}px`, n.style.height = `${t}px`, this.shadowRoot.appendChild(n);
-    const r = new Js(), s = new wt(75, e / t, 0.1, 1e3), a = new ku({ alpha: !0 });
-    a.setSize(e, t), n.appendChild(a.domElement);
-    const o = new In(), c = new ta(), l = new Nt(o, c);
-    r.add(l), s.position.z = 3;
-    const h = () => {
-      requestAnimationFrame(h), l.rotation.x += 0.01, l.rotation.y += 0.01, a.render(r, s);
+    const e = this.config?.width || 200, t = this.config?.height || 200, n = this.config?.port || 8080, r = document.createElement("div");
+    r.style.width = `${e}px`, r.style.height = `${t}px`, this.shadowRoot.appendChild(r);
+    const s = new Js(), a = new wt(75, e / t, 0.1, 1e3), o = new ku({ alpha: !0 });
+    o.setSize(e, t), r.appendChild(o.domElement);
+    const c = new In(), l = new ta(), h = new Nt(c, l);
+    s.add(h), a.position.z = 3;
+    const d = () => {
+      requestAnimationFrame(d), h.rotation.x += 0.01, h.rotation.y += 0.01, o.render(s, a);
     };
-    h();
+    d(), fetch(`http://localhost:${n}/api/hello`).then((f) => f.text()).then((f) => {
+      const m = document.createElement("p");
+      m.textContent = f, r.appendChild(m);
+    }).catch(() => {
+      const f = document.createElement("p");
+      f.textContent = `Failed to reach backend on port ${n}`, r.appendChild(f);
+    });
+  }
+  static getConfigElement() {
+    return document.createElement("dt3d-card-editor");
+  }
+  static getStubConfig() {
+    return { port: 8080, width: 200, height: 200 };
   }
 }
+class Xu extends HTMLElement {
+  setConfig(e) {
+    this.config = e, this.render();
+  }
+  render() {
+    this.shadowRoot || this.attachShadow({ mode: "open" });
+    const e = this.config?.port || 8080;
+    this.shadowRoot.innerHTML = `
+      <label>Port: <input type="number" value="${e}" /></label>
+    `, this.shadowRoot.querySelector("input").addEventListener("change", (t) => {
+      this.config.port = parseInt(t.target.value, 10), this.dispatchEvent(
+        new CustomEvent("config-changed", {
+          detail: { config: this.config }
+        })
+      );
+    });
+  }
+}
+customElements.define("dt3d-card-editor", Xu);
 customElements.define("dt3d-card", Wu);

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -17,6 +17,7 @@ class DT3DCard extends HTMLElement {
   connectedCallback() {
     const width = this.config?.width || 200;
     const height = this.config?.height || 200;
+    const port = this.config?.port || 8080;
 
     const container = document.createElement('div');
     container.style.width = `${width}px`;
@@ -44,7 +45,56 @@ class DT3DCard extends HTMLElement {
       renderer.render(scene, camera);
     };
     animate();
+
+    fetch(`http://localhost:${port}/api/hello`)
+      .then((r) => r.text())
+      .then((text) => {
+        const msg = document.createElement('p');
+        msg.textContent = text;
+        container.appendChild(msg);
+      })
+      .catch(() => {
+        const err = document.createElement('p');
+        err.textContent = `Failed to reach backend on port ${port}`;
+        container.appendChild(err);
+      });
+  }
+
+  static getConfigElement() {
+    return document.createElement('dt3d-card-editor');
+  }
+
+  static getStubConfig() {
+    return { port: 8080, width: 200, height: 200 };
   }
 }
 
+class DT3DCardEditor extends HTMLElement {
+  setConfig(config) {
+    this.config = config;
+    this.render();
+  }
+
+  render() {
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: 'open' });
+    }
+    const port = this.config?.port || 8080;
+    this.shadowRoot.innerHTML = `
+      <label>Port: <input type="number" value="${port}" /></label>
+    `;
+    this.shadowRoot
+      .querySelector('input')
+      .addEventListener('change', (e) => {
+        this.config.port = parseInt(e.target.value, 10);
+        this.dispatchEvent(
+          new CustomEvent('config-changed', {
+            detail: { config: this.config },
+          })
+        );
+      });
+  }
+}
+
+customElements.define('dt3d-card-editor', DT3DCardEditor);
 customElements.define('dt3d-card', DT3DCard);


### PR DESCRIPTION
## Summary
- allow backend port to be set via add-on options
- read port from options.json and serve backend accordingly
- add frontend card editor with port field and backend connection test

## Testing
- `go test ./...`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a87ba501188332a7a733e74028df58