### PR TITLE
Add testing and Home Assistant installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,44 @@ The Go server listens on port `8080` and uses a local SQLite database (`data.db`
 frontend/   - Vite project for the custom card
 addon/      - Go backend and Home Assistant add-on files
 ```
+
+## Testing
+
+### Frontend
+
+The project does not currently include unit tests, but you can verify the
+frontend builds successfully:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+### Backend
+
+Run the Go tests to ensure the backend compiles and its tests (if any) pass:
+
+```bash
+cd addon/backend
+go test ./...
+```
+
+## Home Assistant installation
+
+### Custom card
+
+1. Build the frontend as shown above to produce `frontend/dist/dt3d-card.js`.
+2. Copy the file to your Home Assistant configuration directory, e.g.
+   `config/www/dt3d-card.js`.
+3. In Home Assistant, navigate to **Settings → Dashboards → Resources** and add
+   `/local/dt3d-card.js` as a JavaScript resource.
+4. Add a manual card in the dashboard using the `custom:dt3d-card` element.
+
+### Add-on
+
+1. Copy the `addon` directory into your Home Assistant `addons` folder or add
+   this repository as a custom add-on repository.
+2. Install and start the add-on from **Settings → Add-ons → Add-on Store**.
+3. Verify the add-on is running by visiting
+   `http://<home-assistant>:8080/api/hello`.


### PR DESCRIPTION
## Summary
- Document how to verify the frontend build and run backend Go tests
- Explain how to install the custom card and add-on in Home Assistant

## Testing
- `go test ./...` *(fails: `no test files`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a87fb64d5c8332b9f36395f17c85f1