### PR TITLE
Refine frontend model upload UX

### DIFF
--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -1,7 +1,10 @@
-import {Mesh, BoxGeometry, PerspectiveCamera, Scene, WebGLRenderer, MeshBasicMaterial, Raycaster, Vector2, PlaneGeometry, SphereGeometry, Group, MathUtils, Vector3} from 'three';
+import {Mesh, BoxGeometry, PerspectiveCamera, Scene, WebGLRenderer, MeshBasicMaterial, Raycaster, Vector2, PlaneGeometry, SphereGeometry, Group, MathUtils, Vector3, Object3D} from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import {TransformControls }from 'three/examples/jsm/controls/TransformControls';
 import { Sky } from 'three/examples/jsm/Addons.js';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
+import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js';
 import { LitElement, css } from "lit";
 import { customElement } from 'lit/decorators.js';
 import { DT3DSidebar } from "./side-bar.js";
@@ -25,19 +28,106 @@ export class DT3DCard extends LitElement  {
 
 	private controls: OrbitControls;
 
-	private transform: TransformControls = null;
+        private transform: TransformControls = null;
 
-	/**
-	 * The scene where all 3D objects are placed.
-	 */
-	private scene: Scene;
+        /**
+         * The scene where all 3D objects are placed.
+         */
+        private scene: Scene;
 
-	/**
-	 * The home group that contains all main objects in the scene.	
-	 * 
-	 * This allows for easy manipulation of the entire scene (e.g., moving, scaling, rotating the whole scene). 
-	 */
-	private home: Group;
+        /**
+         * The home group that contains all main objects in the scene.
+         *
+         * This allows for easy manipulation of the entire scene (e.g., moving, scaling, rotating the whole scene).
+         */
+        private home: Group;
+
+        private promptModelUpload() {
+                if (!this.home) {
+                        return;
+                }
+
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.gltf,.glb,.obj,.fbx';
+                input.style.display = 'none';
+
+                input.addEventListener('change', () => {
+                        const file = input.files?.[0];
+                        if (file) {
+                                this.loadModelFromFile(file);
+                        }
+                        input.remove();
+                });
+
+                const host = this.content ?? this;
+                host.appendChild(input);
+                input.click();
+        }
+
+        private loadModelFromFile(file: File) {
+                if (!this.home) {
+                        return;
+                }
+
+                const extension = file.name.split('.').pop()?.toLowerCase();
+
+                if (!extension) {
+                        console.warn('Unable to detect model file extension:', file.name);
+                        return;
+                }
+
+                const url = URL.createObjectURL(file);
+
+                const cleanup = () => {
+                        URL.revokeObjectURL(url);
+                };
+
+                const addToScene = (object: Object3D | null | undefined) => {
+                        if (!object) {
+                                return;
+                        }
+
+                        object.name = file.name;
+                        this.home.add(object);
+                        this.transform?.attach(object);
+                };
+
+                const onError = (error: any) => {
+                        console.error(`Failed to load ${extension} model`, error);
+                        cleanup();
+                };
+
+                if (extension === 'gltf' || extension === 'glb') {
+                        const loader = new GLTFLoader();
+                        loader.load(url, (gltf) => {
+                                cleanup();
+                                addToScene(gltf.scene ?? gltf.scenes?.[0]);
+                        }, undefined, onError);
+                        return;
+                }
+
+                if (extension === 'obj') {
+                        const loader = new OBJLoader();
+                        loader.load(url, (obj) => {
+                                cleanup();
+                                addToScene(obj);
+                        }, undefined, onError);
+                        return;
+                }
+
+                if (extension === 'fbx') {
+                        const loader = new FBXLoader();
+                        loader.load(url, (fbx) => {
+                                cleanup();
+                                addToScene(fbx);
+                        }, undefined, onError);
+                        return;
+                }
+
+                console.warn('Unsupported model format:', extension);
+                cleanup();
+        }
 
 	static properties = {
 		hass: { attribute: false },
@@ -124,12 +214,17 @@ export class DT3DCard extends LitElement  {
 		`;
 		this.content.appendChild(this.canvas);
 
-		const sidebar = document.createElement('dt3d-sidebar') as DT3DSidebar;
-		sidebar.style.cssText = `
-			position: absolute;
-			top: 0;
-			left: 0;
-			height: 100%;
+                this.scene = new Scene();
+
+                this.home = new Group();
+                this.scene.add(this.home);
+
+                const sidebar = document.createElement('dt3d-sidebar') as DT3DSidebar;
+                sidebar.style.cssText = `
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        height: 100%;
 		`;
 		this.content.appendChild(sidebar);
 		
@@ -147,11 +242,11 @@ export class DT3DCard extends LitElement  {
 			this.transform.setMode(tool);
 		});
 
-		sidebar.addEventListener('add-object', (e: any) => {
-			const type = e.detail.type;
+                sidebar.addEventListener('add-object', (e: any) => {
+                        const type = e.detail.type;
 
-			let object: Mesh;
-			const material = new MeshBasicMaterial({ color: 0x00ffff, wireframe: true });
+                        let object: Mesh;
+                        const material = new MeshBasicMaterial({ color: 0x00ffff, wireframe: true });
 
 			if (type === 'cube') {
 				const geometry = new BoxGeometry();
@@ -168,20 +263,19 @@ export class DT3DCard extends LitElement  {
 				object = new Mesh(geometry, material);
 			}
 
-			if (object) {
-				this.transform.attach(object);
-				this.home.add(object);
-			}
-		});
+                        if (object) {
+                                this.transform.attach(object);
+                                this.home.add(object);
+                        }
+                });
+
+                sidebar.addEventListener('upload-model', () => {
+                        this.promptModelUpload();
+                });
 
 
 
-		this.scene = new Scene();
-		
-		this.home = new Group();
-		this.scene.add(this.home);
-
-		this.camera = new PerspectiveCamera(75, width / height, 0.1, 10000);
+                this.camera = new PerspectiveCamera(75, width / height, 0.1, 10000);
 		this.camera.position.z = 3;
 
 		this.renderer = new WebGLRenderer({ alpha: true, canvas: this.canvas });

--- a/frontend/src/side-bar.ts
+++ b/frontend/src/side-bar.ts
@@ -71,10 +71,10 @@ export class DT3DSidebar extends LitElement {
 			transition: background 0.2s;
 		}
 
-		button:hover {
-			background: #3a4050;
-		}
-	`;
+                button:hover {
+                        background: #3a4050;
+                }
+        `;
 
 	static properties = {
 		collapsed: { type: Boolean, reflect: true }
@@ -97,18 +97,25 @@ export class DT3DSidebar extends LitElement {
 		}));
 	}
 
-	private handleAddObject(type: string) {
-		this.dispatchEvent(new CustomEvent('add-object', {
-			detail: { type },
-			bubbles: true,
-			composed: true
-		}));
-	}
+        private handleAddObject(type: string) {
+                this.dispatchEvent(new CustomEvent('add-object', {
+                        detail: { type },
+                        bubbles: true,
+                        composed: true
+                }));
+        }
 
-	render() {
-		return html`
-			<button class="collapse-btn" @click=${this.toggleCollapse} title="Collapse sidebar">
-				${this.collapsed ? '⮞' : '⮜'}
+        private requestModelUpload() {
+                this.dispatchEvent(new CustomEvent('upload-model', {
+                        bubbles: true,
+                        composed: true,
+                }));
+        }
+
+        render() {
+                return html`
+                        <button class="collapse-btn" @click=${this.toggleCollapse} title="Collapse sidebar">
+                                ${this.collapsed ? '⮞' : '⮜'}
 			</button>
 			<div class="sidebar-section">
 				<div class="sidebar-title">Controls</div>
@@ -116,12 +123,16 @@ export class DT3DSidebar extends LitElement {
 				<button @click=${() => this.handleTransformSelect('rotate')}>Rotate</button>
 				<button @click=${() => this.handleTransformSelect('scale')}>Scale</button>
 			</div>
-			<div class="sidebar-section">
-				<div class="sidebar-title">Add Object</div>
-				<button @click=${() => this.handleAddObject('cube')}>Cube</button>
-				<button @click=${() => this.handleAddObject('sphere')}>Sphere</button>
-				<button @click=${() => this.handleAddObject('plane')}>Plane</button>
-			</div>
-		`;
-	}
+                        <div class="sidebar-section">
+                                <div class="sidebar-title">Add Object</div>
+                                <button @click=${() => this.handleAddObject('cube')}>Cube</button>
+                                <button @click=${() => this.handleAddObject('sphere')}>Sphere</button>
+                                <button @click=${() => this.handleAddObject('plane')}>Plane</button>
+                        </div>
+                        <div class="sidebar-section">
+                                <div class="sidebar-title">Upload Model</div>
+                                <button @click=${this.requestModelUpload}>Upload…</button>
+                        </div>
+                `;
+        }
 }


### PR DESCRIPTION
## Summary
- replace the sidebar file input with an Upload button that signals the card to start model selection
- present the file picker from the card and reuse existing loaders to attach uploaded models to the scene

## Testing
- npm run build *(fails: missing /workspace/dt3d-ha/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f23ea81483328e382dc467160968