### PR TITLE
Add drag and drop reordering to object tree

### DIFF
--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -175,10 +175,10 @@ export class DT3DCard extends LitElement  {
 	 * 
 	 * @param object - The 3D object to add to the scene.
 	 */
-	public addToScene(object: Object3D | null | undefined, name?: string): void {
-		if (!object) {
-			return;
-		}
+        public addToScene(object: Object3D | null | undefined, name?: string): void {
+                if (!object) {
+                        return;
+                }
 
 		if (name) {
 			object.name = name;
@@ -186,11 +186,78 @@ export class DT3DCard extends LitElement  {
 
 		console.log('DT3d: Adding object to scene', object, name);
 
-		this.home.add(object);
-		this.transform?.attach(object);
+                this.home.add(object);
+                this.transform?.attach(object);
 
-		this.tree.updateTreeFromScene();
-	};
+                this.tree.updateTreeFromScene();
+        };
+
+        private isDescendant(object: Object3D, potentialAncestor: Object3D): boolean {
+                let current = object.parent;
+                while (current) {
+                        if (current === potentialAncestor) {
+                                return true;
+                        }
+                        current = current.parent;
+                }
+
+                return false;
+        }
+
+        private handleTreeDrop(sourceId: string, targetId: string, position: 'before' | 'after' | 'inside'): void {
+                if (!this.home) {
+                        return;
+                }
+
+                const source = this.home.getObjectByProperty('uuid', sourceId) as Object3D | null;
+                const target = this.home.getObjectByProperty('uuid', targetId) as Object3D | null;
+
+                if (!source || !target || source === target) {
+                        return;
+                }
+
+                if (this.isDescendant(target, source)) {
+                        return;
+                }
+
+                if (position === 'inside') {
+                        if (source.parent !== target) {
+                                target.attach(source);
+                        } else {
+                                const index = target.children.indexOf(source);
+                                if (index > -1) {
+                                        target.children.splice(index, 1);
+                                        target.children.push(source);
+                                }
+                        }
+                } else {
+                        const parent = target.parent;
+                        if (!parent || parent === source) {
+                                return;
+                        }
+
+                        if (source.parent !== parent) {
+                                parent.attach(source);
+                        }
+
+                        const currentIndex = parent.children.indexOf(source);
+                        if (currentIndex === -1) {
+                                return;
+                        }
+
+                        parent.children.splice(currentIndex, 1);
+
+                        const targetIndex = parent.children.indexOf(target);
+                        let newIndex = position === 'before' ? targetIndex : targetIndex + 1;
+                        if (newIndex > parent.children.length) {
+                                newIndex = parent.children.length;
+                        }
+
+                        parent.children.splice(newIndex, 0, source);
+                }
+
+                this.tree.updateTreeFromScene();
+        }
 
 
 	/**
@@ -357,13 +424,18 @@ export class DT3DCard extends LitElement  {
 		this.tree.updateTreeFromScene();
 
 		// Listen for selection events from the tree
-		this.tree.addEventListener('object-selected', (e: any) => {
-			const id = e.detail.id;
-			const object = this.home.getObjectByProperty('uuid', id);
-			if (object) {
-				this.transform.attach(object);
-			}
-		});
+                this.tree.addEventListener('object-selected', (e: any) => {
+                        const id = e.detail.id;
+                        const object = this.home.getObjectByProperty('uuid', id);
+                        if (object) {
+                                this.transform.attach(object);
+                        }
+                });
+
+                this.tree.addEventListener('object-dropped', (e: any) => {
+                        const { sourceId, targetId, position } = e.detail as { sourceId: string; targetId: string; position: 'before' | 'after' | 'inside' };
+                        this.handleTreeDrop(sourceId, targetId, position);
+                });
 
 		// Raycaster for object picking
 		const raycaster = new Raycaster();

--- a/frontend/src/object-tree.ts
+++ b/frontend/src/object-tree.ts
@@ -10,6 +10,8 @@ interface TreeNode {
     children?: TreeNode[];
 }
 
+type DropPosition = 'before' | 'after' | 'inside';
+
 @customElement('dt3d-tree')
 export class DT3DTree extends LitElement {
     static styles = css`
@@ -32,9 +34,27 @@ export class DT3DTree extends LitElement {
         .tree-node.selected {
             background: #3a4050;
         }
+        .tree-node.dragging {
+            opacity: 0.6;
+        }
+        .tree-node.drop-target {
+            background: #2a7fff55;
+        }
         .toggle {
             cursor: pointer;
             margin-right: 4px;
+        }
+        .drop-zone {
+            height: 6px;
+            margin: 2px 0;
+            border: 1px dashed transparent;
+        }
+        .drop-zone.visible {
+            border-color: #3a405088;
+        }
+        .drop-zone.active {
+            border-color: #3aa0ff;
+            background: #3aa0ff55;
         }
     `;
     
@@ -60,6 +80,18 @@ export class DT3DTree extends LitElement {
      * Tree data structure representing the 3D scene graph.
      */
     public tree: TreeNode[] = [];
+
+    /**
+     * Currently dragged node ID.
+     */
+    @state()
+    private draggedId: UUID = null;
+
+    /**
+     * Active drop target descriptor.
+     */
+    @state()
+    private dropTarget: { id: UUID; position: DropPosition } = null;
 
     /**
      * React to property changes.
@@ -113,10 +145,148 @@ export class DT3DTree extends LitElement {
         }
     }
 
+    private findParentId(nodes: TreeNode[], childId: UUID, parentId: UUID = null): UUID | null {
+        for (const node of nodes) {
+            if (node.id === childId) {
+                return parentId;
+            }
+
+            if (node.children) {
+                const result = this.findParentId(node.children, childId, node.id);
+                if (result !== null) {
+                    return result;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private isAncestor(ancestorId: UUID, nodeId: UUID): boolean {
+        if (!ancestorId || !nodeId || ancestorId === nodeId) {
+            return false;
+        }
+
+        const parentId = this.findParentId(this.tree, nodeId);
+        if (parentId === null) {
+            return false;
+        }
+
+        if (parentId === ancestorId) {
+            return true;
+        }
+
+        return this.isAncestor(ancestorId, parentId);
+    }
+
+    private canDrop(targetId: UUID, position: DropPosition): boolean {
+        if (!this.draggedId || this.draggedId === targetId) {
+            return false;
+        }
+
+        if (this.isAncestor(this.draggedId, targetId)) {
+            return false;
+        }
+
+        if (position === 'inside') {
+            return true;
+        }
+
+        const parentId = this.findParentId(this.tree, targetId);
+        if (parentId === null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private handleDragStart(event: DragEvent, id: UUID) {
+        event.dataTransfer?.setData('text/plain', id);
+        if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+        }
+        this.draggedId = id;
+    }
+
+    private handleDragEnd() {
+        this.draggedId = null;
+        this.dropTarget = null;
+    }
+
+    private handleDragOver(event: DragEvent, id: UUID, position: DropPosition) {
+        if (!this.canDrop(id, position)) {
+            return;
+        }
+
+        event.preventDefault();
+        if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+        }
+
+        this.dropTarget = { id, position };
+    }
+
+    private handleDragLeave(_event: DragEvent, id: UUID, position: DropPosition) {
+        if (this.dropTarget && this.dropTarget.id === id && this.dropTarget.position === position) {
+            this.dropTarget = null;
+        }
+    }
+
+    private handleDrop(event: DragEvent, id: UUID, position: DropPosition) {
+        if (!this.canDrop(id, position)) {
+            return;
+        }
+
+        event.preventDefault();
+        const sourceId = event.dataTransfer?.getData('text/plain') || this.draggedId;
+        if (!sourceId) {
+            return;
+        }
+
+        if (position === 'inside') {
+            const expanded = new Set(this.expanded);
+            expanded.add(id);
+            this.expanded = expanded;
+        }
+
+        this.dispatchEvent(new CustomEvent('object-dropped', {
+            detail: { sourceId, targetId: id, position },
+            bubbles: true,
+            composed: true
+        }));
+
+        this.draggedId = null;
+        this.dropTarget = null;
+    }
+
+    private renderDropZone(id: UUID, position: DropPosition, depth: number): any {
+        if (!this.draggedId || (depth === 0 && position !== 'inside')) {
+            return null;
+        }
+
+        const classes = ["drop-zone"];
+        if (this.draggedId) {
+            classes.push('visible');
+        }
+
+        if (this.dropTarget && this.dropTarget.id === id && this.dropTarget.position === position) {
+            classes.push('active');
+        }
+
+        return html`
+            <div
+                class="${classes.join(' ')}"
+                @dragover=${(dragEvent: DragEvent) => this.handleDragOver(dragEvent, id, position)}
+                @dragleave=${(dragEvent: DragEvent) => this.handleDragLeave(dragEvent, id, position)}
+                @drop=${(dragEvent: DragEvent) => this.handleDrop(dragEvent, id, position)}
+            ></div>
+        `;
+    }
+
     /**
      * Select a node by its ID, dispatching an event.
-     * 
-     * @param id - The ID of the node to select. 
+     *
+     * @param id - The ID of the node to select.
      */
     private selectNode(id: UUID) {
         this.selectedId = id;
@@ -134,13 +304,20 @@ export class DT3DTree extends LitElement {
      * @param nodes - The tree nodes to render.
      * @returns Rendered HTML template.
      */
-    private renderTree(nodes: TreeNode[]): any {
+    private renderTree(nodes: TreeNode[], depth: number = 0): any {
         return html`
             <ul style="list-style: none; margin: 0; padding: 0;">
                 ${nodes.map(node => html`
                     <li>
+                        ${this.renderDropZone(node.id, 'before', depth)}
                         <div
-                            class="tree-node ${this.selectedId === node.id ? 'selected' : ''}"
+                            class="tree-node ${this.selectedId === node.id ? 'selected' : ''} ${this.draggedId === node.id ? 'dragging' : ''} ${this.dropTarget && this.dropTarget.id === node.id && this.dropTarget.position === 'inside' ? 'drop-target' : ''}"
+                            draggable=${depth > 0}
+                            @dragstart=${(dragEvent: DragEvent) => this.handleDragStart(dragEvent, node.id)}
+                            @dragend=${() => this.handleDragEnd()}
+                            @dragover=${(dragEvent: DragEvent) => this.handleDragOver(dragEvent, node.id, 'inside')}
+                            @dragleave=${(dragEvent: DragEvent) => this.handleDragLeave(dragEvent, node.id, 'inside')}
+                            @drop=${(dragEvent: DragEvent) => this.handleDrop(dragEvent, node.id, 'inside')}
                             @click=${() => this.selectNode(node.id)}
                         >
                             ${node.children && node.children.length
@@ -154,8 +331,9 @@ export class DT3DTree extends LitElement {
                             ${node.name}
                         </div>
                         ${node.children && node.children.length && this.expanded.has(node.id)
-                            ? this.renderTree(node.children)
+                            ? this.renderTree(node.children, depth + 1)
                             : null}
+                        ${this.renderDropZone(node.id, 'after', depth)}
                     </li>
                 `)}
             </ul>


### PR DESCRIPTION
## Summary
- add drag-and-drop affordances to the object tree, including drop zones and visual cues
- dispatch drop events so parents can reorder and reparent Three.js objects
- update the card to handle drop events and keep the hierarchy in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f4ded94948833283203ded3e9ac833