### PR TITLE
Apply shared styles to GUI components

### DIFF
--- a/frontend/src/config-editor.ts
+++ b/frontend/src/config-editor.ts
@@ -1,11 +1,48 @@
-import { LitElement, html} from "lit";
+import { LitElement, html, css, unsafeCSS} from "lit";
 import { customElement } from "lit/decorators.js";
+import style from './style.css?inline';
 
 @customElement('dt3d-config-editor')
 export class DT3DConfigEditor extends LitElement {
-	static properties = {
-		_config: { state: true },
-	};
+        static styles = [unsafeCSS(style), css`
+                :host {
+                        display: block;
+                        color: var(--dt3d-text-primary);
+                        background: var(--dt3d-card-bg);
+                        padding: 8px;
+                        border: 1px solid var(--dt3d-card-border);
+                        border-radius: 8px;
+                        box-shadow: 0 2px 4px color-mix(in srgb, var(--dt3d-gray-999) 10%, transparent);
+                        font-family: "Roboto", "Noto", sans-serif;
+                }
+
+                label {
+                        display: block;
+                        margin-bottom: 6px;
+                        font-weight: 600;
+                        color: var(--dt3d-text-secondary);
+                }
+
+                input {
+                        width: 100%;
+                        padding: 8px;
+                        border-radius: 6px;
+                        border: 1px solid var(--dt3d-card-border);
+                        background: var(--dt3d-gray-000);
+                        color: var(--dt3d-text-primary);
+                        box-sizing: border-box;
+                        font-size: 1em;
+                }
+
+                input:focus {
+                        border-color: var(--dt3d-primary);
+                        outline: none;
+                        box-shadow: 0 0 0 2px color-mix(in srgb, var(--dt3d-primary-light) 50%, transparent);
+                }
+        `];
+        static properties = {
+                _config: { state: true },
+        };
 	private _config: any;
 
 	public setConfig(config: any) {

--- a/frontend/src/object-tree.ts
+++ b/frontend/src/object-tree.ts
@@ -1,6 +1,7 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, unsafeCSS } from "lit";
 import { customElement, property, state } from 'lit/decorators.js';
 import type { Object3D, Scene } from "three";
+import style from './style.css?inline';
 
 type UUID = string;
 
@@ -18,12 +19,12 @@ type DropPosition = 'before' | 'after' | 'inside';
 @customElement('dt3d-tree')
 export class DT3DTree extends LitElement {
 
-    static styles = css`
+    static styles = [unsafeCSS(style), css`
         :host {
             display: block;
             width: 220px;
-            background: #23272f55;
-            color: #fff;
+            background: color-mix(in srgb, var(--dt3d-card-bg) 90%, transparent);
+            color: var(--dt3d-text-primary);
             height: 100%;
             padding: 16px 0;
             z-index: 1;
@@ -37,19 +38,22 @@ export class DT3DTree extends LitElement {
             text-overflow: ellipsis;
             white-space: nowrap;
             width: 100%;
+            color: var(--dt3d-text-secondary);
         }
         .tree-node.selected {
-            background: #3a4050;
+            background: color-mix(in srgb, var(--dt3d-primary-light) 40%, transparent);
+            color: var(--dt3d-text-primary);
         }
         .tree-node.dragging {
             opacity: 0.6;
         }
         .tree-node.drop-target {
-            background: #2a7fff55;
+            background: color-mix(in srgb, var(--dt3d-primary) 35%, transparent);
         }
         .toggle {
             cursor: pointer;
             margin-right: 4px;
+            color: var(--dt3d-primary);
         }
         .drop-zone {
             height: 6px;
@@ -57,13 +61,13 @@ export class DT3DTree extends LitElement {
             border: 1px dashed transparent;
         }
         .drop-zone.visible {
-            border-color: #3a405088;
+            border-color: color-mix(in srgb, var(--dt3d-primary) 30%, transparent);
         }
         .drop-zone.active {
-            border-color: #3aa0ff;
-            background: #3aa0ff55;
+            border-color: var(--dt3d-primary);
+            background: color-mix(in srgb, var(--dt3d-primary) 35%, transparent);
         }
-    `;
+    `];
     
     /**
      * The 3D scene to visualize.

--- a/frontend/src/side-bar.ts
+++ b/frontend/src/side-bar.ts
@@ -1,80 +1,89 @@
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, unsafeCSS } from "lit";
 import { customElement } from 'lit/decorators.js';
+import style from './style.css?inline';
 
 @customElement('dt3d-sidebar')
 export class DT3DSidebar extends LitElement {
-	static styles = css`
-		:host {
-			display: block;
-			width: 220px;
-			background: #363a4255;
-			color: #fff;
-			height: 100%;
-			padding: 16px 0;
-			z-index: 1;
-			transition: width 0.2s;
-			overflow: hidden;
-		}
+        static styles = [unsafeCSS(style), css`
+                :host {
+                        display: block;
+                        width: 220px;
+                        background: color-mix(in srgb, var(--dt3d-card-bg-dark) 90%, transparent);
+                        color: var(--dt3d-text-inverted);
+                        height: 100%;
+                        padding: 16px 0;
+                        z-index: 1;
+                        transition: width 0.2s;
+                        overflow: hidden;
+                }
 
-		:host([collapsed]) {
-			width: 40px;
-			padding: 16px 0 16px 0;
-		}
+                :host([collapsed]) {
+                        width: 40px;
+                        padding: 16px 0 16px 0;
+                }
 
-		.collapse-btn {
-			position: absolute;
-			top: 12px;
-			right: 8px;
-			background: none;
-			border: none;
-			color: #fff;
-			cursor: pointer;
-			font-size: 1.2em;
-			width: 24px;
-			height: 24px;
-			padding: 0;
-			z-index: 10;
-		}
+                .collapse-btn {
+                        position: absolute;
+                        top: 12px;
+                        right: 8px;
+                        background: none;
+                        border: none;
+                        color: var(--dt3d-text-inverted);
+                        cursor: pointer;
+                        font-size: 1.2em;
+                        width: 24px;
+                        height: 24px;
+                        padding: 0;
+                        z-index: 10;
+                }
 
-		.sidebar-section {
-			margin-bottom: 24px;
-			padding: 0 16px;
-			transition: opacity 0.2s;
-		}
+                .sidebar-section {
+                        margin-bottom: 24px;
+                        padding: 0 16px;
+                        transition: opacity 0.2s;
+                }
 
-		:host([collapsed]) .sidebar-section {
-			opacity: 0;
-			pointer-events: none;
-			height: 0;
-			padding: 0;
-			margin: 0;
-		}
+                :host([collapsed]) .sidebar-section {
+                        opacity: 0;
+                        pointer-events: none;
+                        height: 0;
+                        padding: 0;
+                        margin: 0;
+                }
 
-		.sidebar-title {
-			font-size: 1.1em;
-			margin-bottom: 8px;
-			font-weight: bold;
-			letter-spacing: 1px;
-		}
+                .sidebar-title {
+                        font-size: 1.1em;
+                        margin-bottom: 8px;
+                        font-weight: bold;
+                        letter-spacing: 1px;
+                        color: var(--dt3d-primary-light);
+                }
 
-		button {
-			display: block;
-			width: 100%;
-			margin-bottom: 8px;
-			padding: 10px 0;
-			background: #2d323c;
-			color: #fff;
-			border: none;
-			border-radius: 4px;
-			cursor: pointer;
-			font-size: 1em;
-			transition: background 0.2s;
-		}
+                button {
+                        display: block;
+                        width: 100%;
+                        margin-bottom: 8px;
+                        padding: 10px 0;
+                        background: var(--dt3d-primary-dark);
+                        color: var(--dt3d-text-inverted);
+                        border: none;
+                        border-radius: 4px;
+                        cursor: pointer;
+                        font-size: 1em;
+                        transition: background 0.2s, transform 0.2s;
+                        box-shadow: 0 2px 4px color-mix(in srgb, var(--dt3d-gray-999) 20%, transparent);
+                }
 
-		button:hover {
-			background: #3a4050;
-		}
-	`;
+                button:hover {
+                        background: var(--dt3d-primary);
+                        transform: translateY(-1px);
+                }
+
+                button:active {
+                        background: var(--dt3d-primary-dark);
+                        transform: translateY(0);
+                }
+        `];
 
 	static properties = {
 		collapsed: { type: Boolean, reflect: true }


### PR DESCRIPTION
## Summary
- import the shared style sheet into sidebar, tree, and config editor components
- restyle GUI elements to use shared theme variables and improved hover/focus states
- add layout and form styling to the configuration editor for consistent appearance

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b3641f6f483329bca26c2fd8d1294)