### PR TITLE
Add resizing handles for sidebar and object tree panels

### DIFF
--- a/frontend/src/object-tree.ts
+++ b/frontend/src/object-tree.ts
@@ -29,7 +29,7 @@ export class DT3DTree extends LitElement {
             padding: 12px 0;
             z-index: 1;
             transition: width 0.2s;
-            overflow: hidden;
+            overflow: visible;
             position: relative;
         }
         .panel {
@@ -165,6 +165,17 @@ export class DT3DTree extends LitElement {
         .context-menu button:hover {
             background: color-mix(in srgb, var(--ha-color-primary-60) 25%, transparent);
         }
+
+        .resize-handle {
+            position: absolute;
+            top: 0;
+            left: -4px;
+            width: 8px;
+            height: 100%;
+            cursor: ew-resize;
+            z-index: 5;
+            background: transparent;
+        }
     `];
     
     /**
@@ -213,6 +224,42 @@ export class DT3DTree extends LitElement {
      */
     @state()
     private contextMenu: { id: UUID; x: number; y: number } | null = null;
+
+    private resizing = false;
+
+    private handleResizeMove = (event: MouseEvent) => {
+        if (!this.resizing) {
+            return;
+        }
+
+        const rect = this.getBoundingClientRect();
+        const nextWidth = Math.min(Math.max(rect.right - event.clientX, 200), 420);
+        this.style.width = `${nextWidth}px`;
+    };
+
+    private handleResizeEnd = () => {
+        if (!this.resizing) {
+            return;
+        }
+
+        this.resizing = false;
+        document.body.style.cursor = '';
+        window.removeEventListener('mousemove', this.handleResizeMove);
+        window.removeEventListener('mouseup', this.handleResizeEnd);
+    };
+
+    private startResize(_event: MouseEvent) {
+        this.resizing = true;
+        document.body.style.cursor = 'ew-resize';
+
+        window.addEventListener('mousemove', this.handleResizeMove);
+        window.addEventListener('mouseup', this.handleResizeEnd);
+    }
+
+    public disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.handleResizeEnd();
+    }
 
     /**
      * React to property changes.
@@ -598,6 +645,7 @@ export class DT3DTree extends LitElement {
 
     public render() {
         return html`
+            <div class="resize-handle" @mousedown=${(event: MouseEvent) => this.startResize(event)}></div>
             <div class="panel">
                 <div class="tree-section">
                     ${this.renderTree(this.tree)}

--- a/frontend/src/side-bar.ts
+++ b/frontend/src/side-bar.ts
@@ -13,7 +13,8 @@ export class DT3DSidebar extends LitElement {
                         padding: 16px 0;
                         z-index: 1;
                         transition: width 0.2s;
-                        overflow: hidden;
+                        overflow: visible;
+                        position: relative;
                 }
 
                 :host([collapsed]) {
@@ -82,13 +83,68 @@ export class DT3DSidebar extends LitElement {
                         background: var(--ha-color-primary-60);
                         transform: translateY(0);
                 }
+
+                .resize-handle {
+                        position: absolute;
+                        top: 0;
+                        right: -4px;
+                        width: 8px;
+                        height: 100%;
+                        cursor: ew-resize;
+                        z-index: 5;
+                        background: transparent;
+                }
         `];
 
-	static properties = {
-		collapsed: { type: Boolean, reflect: true }
-	};
+        static properties = {
+                collapsed: { type: Boolean, reflect: true }
+        };
 
-	public collapsed = true;
+        public collapsed = true;
+
+        private resizing = false;
+        private startX = 0;
+        private startWidth = 220;
+
+        private handleResizeMove = (event: MouseEvent) => {
+                if (!this.resizing) {
+                        return;
+                }
+
+                const delta = event.clientX - this.startX;
+                const nextWidth = Math.min(Math.max(this.startWidth + delta, 160), 400);
+                this.style.width = `${nextWidth}px`;
+        };
+
+        private handleResizeEnd = () => {
+                if (!this.resizing) {
+                        return;
+                }
+
+                this.resizing = false;
+                document.body.style.cursor = '';
+                window.removeEventListener('mousemove', this.handleResizeMove);
+                window.removeEventListener('mouseup', this.handleResizeEnd);
+        };
+
+        public disconnectedCallback(): void {
+                super.disconnectedCallback();
+                this.handleResizeEnd();
+        }
+
+        private startResize(event: MouseEvent) {
+                if (this.collapsed) {
+                        return;
+                }
+
+                this.resizing = true;
+                this.startX = event.clientX;
+                this.startWidth = this.getBoundingClientRect().width;
+                document.body.style.cursor = 'ew-resize';
+
+                window.addEventListener('mousemove', this.handleResizeMove);
+                window.addEventListener('mouseup', this.handleResizeEnd);
+        }
 
 	private toggleCollapse() {
 		this.collapsed = !this.collapsed;
@@ -125,10 +181,11 @@ export class DT3DSidebar extends LitElement {
                 return html`
                         <button class="collapse-btn" @click=${this.toggleCollapse} title="Collapse sidebar">
                                 ${this.collapsed ? '⮞' : '⮜'}
-			</button>
-			<div class="sidebar-section">
-				<div class="sidebar-title">Controls</div>
-				<button @click=${() => this.handleTransformSelect('translate')}>Translate</button>
+                        </button>
+                        <div class="resize-handle" @mousedown=${(event: MouseEvent) => this.startResize(event)}></div>
+                        <div class="sidebar-section">
+                                <div class="sidebar-title">Controls</div>
+                                <button @click=${() => this.handleTransformSelect('translate')}>Translate</button>
 				<button @click=${() => this.handleTransformSelect('rotate')}>Rotate</button>
 				<button @click=${() => this.handleTransformSelect('scale')}>Scale</button>
 			</div>


### PR DESCRIPTION
## Summary
- add drag handles that allow resizing the left sidebar and right object tree panels
- ensure resize interactions clean up listeners when components disconnect and show appropriate cursors

## Testing
- not run (npm command unavailable in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340879cfd083329043391fd65b5e53)