### PR TITLE
Keep property inspector in sync with transform control changes

### DIFF
--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -620,11 +620,14 @@ export class DT3DCard extends LitElement  {
 		this.controls.enableDamping = true; // Enable damping for smoother controls
 		this.controls.dampingFactor = 0.05;
 
-		this.transform = new TransformControls( this.camera, this.renderer.domElement );
-		this.transform.addEventListener( 'dragging-changed', ( event: any) => {
-			this.controls.enabled = ! event.value;
-		} );
-		this.scene.add( this.transform.getHelper() );
+                this.transform = new TransformControls( this.camera, this.renderer.domElement );
+                this.transform.addEventListener( 'dragging-changed', ( event: any) => {
+                        this.controls.enabled = ! event.value;
+                } );
+                this.transform.addEventListener('objectChange', () => {
+                        this.tree.refreshSelectedObject();
+                });
+                this.scene.add( this.transform.getHelper() );
 
 		// Add a cube
 		const geometry = new BoxGeometry();

--- a/frontend/src/object-tree.ts
+++ b/frontend/src/object-tree.ts
@@ -460,6 +460,18 @@ export class DT3DTree extends LitElement {
         this.closeContextMenu();
     }
 
+    /**
+     * Refresh the inspector panel when the selected object changes externally.
+     */
+    public refreshSelectedObject() {
+        if (!this.selectedId || !this.scene) {
+            return;
+        }
+
+        this.selectedObject = this.scene.getObjectByProperty('uuid', this.selectedId) ?? null;
+        this.requestUpdate();
+    }
+
     private handleNameChange(event: Event) {
         if (!this.selectedObject) return;
 


### PR DESCRIPTION
## Summary
- add a refresh helper on the tree inspector to reload the currently selected object
- trigger inspector refresh whenever transform controls modify an attached object so fields stay in sync

## Testing
- npm run build *(fails: npm command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340899c890833299fbc4a1089870be)