### PR TITLE
Add SDF text labels and replace sprite text

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
 	},
 	"dependencies": {
 		"three": "~0.180.0",
-		"lit": "~3.3.1"
+		"lit": "~3.3.1",
+		"troika-three-text": "~0.52.2"
 	},
 	"devDependencies": {
 		"@types/three": "~0.180.0",

--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -31,7 +31,7 @@ import { DT3DTree } from "./object-tree.js";
 import { Locale } from "./locale.js";
 import { EntityLight } from "./objects/entity-light.js";
 import { EntitySensor } from "./objects/entity-sensor.js";
-import { TextSprite } from "./objects/text-sprite.js";
+import { SdfText } from "./objects/sdf-text.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -476,10 +476,10 @@ export class DT3DCard extends LitElement {
 		this.measurementHelpers.add(line);
 
 		const distance = start.distanceTo(end);
-		const label = new TextSprite(`Distance: ${distance.toFixed(2)}`);
-		label.position.copy(start.clone().add(end).multiplyScalar(0.5));
-		label.position.y += 0.2;
-		this.measurementHelpers.add(label);
+                const label = new SdfText(`Distance: ${distance.toFixed(2)}`);
+                label.position.copy(start.clone().add(end).multiplyScalar(0.5));
+                label.position.y += 0.2;
+                this.measurementHelpers.add(label);
 	}
 
 	/**
@@ -516,10 +516,10 @@ export class DT3DCard extends LitElement {
 		const angle = Math.acos(MathUtils.clamp(v1.dot(v2), -1, 1));
 		const degrees = MathUtils.radToDeg(angle);
 
-		const label = new TextSprite(`Angle: ${degrees.toFixed(1)}°`);
-		label.position.copy(vertex);
-		label.position.y += 0.5;
-		this.measurementHelpers.add(label);
+                const label = new SdfText(`Angle: ${degrees.toFixed(1)}°`);
+                label.position.copy(vertex);
+                label.position.y += 0.5;
+                this.measurementHelpers.add(label);
 	}
 
 	/**

--- a/frontend/src/objects/entity-light.ts
+++ b/frontend/src/objects/entity-light.ts
@@ -1,9 +1,9 @@
 import {
-	Color,
-	Group,
-	PointLight,
+        Color,
+        Group,
+        PointLight,
 } from "three";
-import { TextSprite } from "./text-sprite.js";
+import { SdfText } from "./sdf-text.js";
 import { CircleIconSprite } from "./circle-icon-sprite.js";
 
 
@@ -43,12 +43,8 @@ export class EntityLight extends Group {
 		pointLight.position.y = 0.4;
 		this.add(pointLight);
 
-		const label = new TextSprite(
-			entity.attributes?.friendly_name ?? entityId,
-			256,
-			96,
-		);
-		label.position.y = 0.6;
-		this.add(label);
-	}
+                const label = new SdfText(entity.attributes?.friendly_name ?? entityId);
+                label.position.y = 0.6;
+                this.add(label);
+        }
 }

--- a/frontend/src/objects/entity-sensor.ts
+++ b/frontend/src/objects/entity-sensor.ts
@@ -1,12 +1,12 @@
 import { Group } from "three";
-import { TextSprite } from "./text-sprite.js";
+import { SdfText } from "./sdf-text.js";
 import { CircleIconSprite } from "./circle-icon-sprite.js";
 
 /**
  * Creates a entity sensor representation.
  */
 export class EntitySensor extends Group {
-    public label: TextSprite;
+    public label: SdfText;
 
 	public constructor(entityId: string, entity: any) {
 		super();
@@ -19,9 +19,9 @@ export class EntitySensor extends Group {
 		const friendlyName = entity.attributes?.friendly_name ?? entityId;
 		const labelText = `${friendlyName}\n${entity.state}`;
 
-		this.label = new TextSprite(labelText);
-		this.label.position.y = 0.45;
-		this.add(this.label);
+                this.label = new SdfText(labelText, 0.16);
+                this.label.position.y = 0.45;
+                this.add(this.label);
 	}
 
     /**
@@ -32,8 +32,6 @@ export class EntitySensor extends Group {
     public updateState(entity: any): void {
         const friendlyName = entity.attributes?.friendly_name ?? this.name;
         const labelText = `${friendlyName}\n${entity.state}`;
-        this.label.material.map.dispose(); 
-        this.label.material.map = new TextSprite(labelText).material.map;
-        this.label.material.needsUpdate = true; 
+        this.label.setText(labelText);
     }
 }

--- a/frontend/src/objects/sdf-text.ts
+++ b/frontend/src/objects/sdf-text.ts
@@ -1,0 +1,29 @@
+import type { ColorRepresentation } from "three";
+import { Text } from "troika-three-text";
+
+export class SdfText extends Text {
+        public constructor(
+                text: string,
+                fontSize = 0.18,
+                color: ColorRepresentation = 0xffffff,
+        ) {
+                super();
+
+                this.text = text;
+                this.fontSize = fontSize;
+                this.color = color;
+                this.anchorX = "center";
+                this.anchorY = "top";
+                this.outlineWidth = 0.0025;
+                this.outlineColor = 0x000000;
+                this.maxWidth = 2.4;
+                this.overflowWrap = "break-word";
+
+                this.sync();
+        }
+
+        public setText(value: string): void {
+                this.text = value;
+                this.sync();
+        }
+}


### PR DESCRIPTION
## Summary
- add a reusable SDF text helper built on troika-three-text for consistent 3D labels
- replace existing sprite-based labels for entities and measurement helpers with SDF text
- add the troika-three-text dependency for SDF text rendering

## Testing
- npm run build --prefix frontend


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a08e59208332a7258f6a0beeacc7)