### PR TITLE
Add switch entity object with tap toggle support

### DIFF
--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -32,6 +32,7 @@ import { Locale } from "./locale.js";
 import { EntityLight } from "./objects/entity-light.js";
 import { EntitySensor } from "./objects/entity-sensor.js";
 import { EntitySwitch } from "./objects/entity-switch.js";
+import { EntityObject } from "./objects/entity-object.js";
 import { TextSprite } from "./objects/text-sprite.js";
 
 @customElement("dt3d-card")
@@ -101,20 +102,22 @@ export class DT3DCard extends LitElement {
 	};
 	public locale: Locale;
 
-	set hass(hass: any) {
-		if (!this.hassInstance) {
-			console.log("DT3D: Entity states", this, DT3DCard.styles, hass.states);
-		}
+        set hass(hass: any) {
+                if (!this.hassInstance) {
+                        console.log("DT3D: Entity states", this, DT3DCard.styles, hass.states);
+                }
 
-		// console.log('DT3D: Styles loaded from file', style);
+                // console.log('DT3D: Styles loaded from file', style);
 
 		// this.locale = new Locale();
 		// this.locale.load('en', en);
 
-		// console.log('DT3D: Translation data loaded ', this.locale);
+                // console.log('DT3D: Translation data loaded ', this.locale);
 
-		this.hassInstance = hass;
-	}
+                this.hassInstance = hass;
+
+                this.updateEntityObjects();
+        }
 
 	/**
 	 * Select a 3D model file to upload.
@@ -430,14 +433,14 @@ export class DT3DCard extends LitElement {
                         return;
                 }
 
-                const switchEntity = this.pickSwitchFromEvent(event);
+                const entityObject = this.pickEntityObjectFromEvent(event);
 
-                if (switchEntity) {
-                        switchEntity.toggle(this.hassInstance);
+                if (entityObject) {
+                        entityObject.handleClick(this.hassInstance);
                 }
         }
 
-        private pickSwitchFromEvent(event: MouseEvent): EntitySwitch | null {
+        private pickEntityObjectFromEvent(event: MouseEvent): EntityObject | null {
                 if (!this.canvas || !this.camera || !this.home) {
                         return null;
                 }
@@ -456,7 +459,7 @@ export class DT3DCard extends LitElement {
                 let current = target as Object3D | null;
 
                 while (current) {
-                        if (current instanceof EntitySwitch) {
+                        if (current instanceof EntityObject) {
                                 return current;
                         }
 
@@ -985,11 +988,11 @@ export class DT3DCard extends LitElement {
 	 *
 	 * @param entityId - The ID of the entity to add.
 	 */
-	private addEntityToScene(entityId: string): void {
-		const entity = this.hassInstance.states[entityId];
-		if (!entity) {
-			console.warn("DT3D: Entity not found:", entityId);
-			return;
+        private addEntityToScene(entityId: string): void {
+                const entity = this.hassInstance.states[entityId];
+                if (!entity) {
+                        console.warn("DT3D: Entity not found:", entityId);
+                        return;
 		}
 
 		const domain = entityId.split(".")[0];
@@ -1005,13 +1008,28 @@ export class DT3DCard extends LitElement {
                         object = this.createDefaultEntityRepresentation(entityId);
                 }
 
-		if (!object) {
-			return;
-		}
+                if (!object) {
+                        return;
+                }
 
-		object.position.set(Math.random() * 2 - 1, 0, Math.random() * 2 - 1);
-		this.addToScene(object, entityId);
-	}
+                object.position.set(Math.random() * 2 - 1, 0, Math.random() * 2 - 1);
+                this.addToScene(object, entityId);
+        }
+
+        private updateEntityObjects(): void {
+                if (!this.home || !this.hassInstance?.states) {
+                        return;
+                }
+
+                this.home.traverse((child) => {
+                        if (child instanceof EntityObject) {
+                                const entityState = this.hassInstance.states[child.entityId];
+                                if (entityState) {
+                                        child.setEntity(entityState);
+                                }
+                        }
+                });
+        }
 
 	/**
 	 * Default placeholder for unsupported entity domains.

--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -10,13 +10,14 @@ import {
 	Vector2,
 	PlaneGeometry,
 	SphereGeometry,
-	Group,
-	MathUtils,
-	Vector3,
-	Object3D,
-	Line,
-	BufferGeometry,
-	LineBasicMaterial,
+        Group,
+        MathUtils,
+        Vector3,
+        Object3D,
+        Intersection,
+        Line,
+        BufferGeometry,
+        LineBasicMaterial,
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls";
@@ -33,6 +34,7 @@ import { EntityLight } from "./objects/entity-light.js";
 import { EntitySensor } from "./objects/entity-sensor.js";
 import { EntitySwitch } from "./objects/entity-switch.js";
 import { EntityObject } from "./objects/entity-object.js";
+import { DTObject } from "./objects/dt-object.js";
 import { TextSprite } from "./objects/text-sprite.js";
 
 @customElement("dt3d-card")
@@ -90,11 +92,13 @@ export class DT3DCard extends LitElement {
 	/**
 	 * Helper group that renders measurement visuals (markers, lines, labels).
 	 */
-	private measurementHelpers: Group = null;
+        private measurementHelpers: Group = null;
 
-	private raycaster: Raycaster = new Raycaster();
+        private raycaster: Raycaster = new Raycaster();
 
-	private pointer: Vector2 = new Vector2();
+        private pointer: Vector2 = new Vector2();
+
+        private hoveredObject: DTObject | null = null;
 
 	static properties = {
 		hass: { attribute: false },
@@ -241,22 +245,26 @@ export class DT3DCard extends LitElement {
 	 *
 	 * @param object - The 3D object to add to the scene.
 	 */
-	public addToScene(object: Object3D | null | undefined, name?: string): void {
-		if (!object) {
-			return;
-		}
+        public addToScene(object: Object3D | null | undefined, name?: string): void {
+                if (!object) {
+                        return;
+                }
 
-		if (name) {
-			object.name = name;
-		}
+                if (name) {
+                        object.name = name;
+                }
 
-		console.log("DT3d: Adding object to scene", object, name);
+                console.log("DT3d: Adding object to scene", object, name);
 
-		this.home.add(object);
-		this.transform?.attach(object);
+                if (object instanceof DTObject) {
+                        object.ensureInitialized();
+                }
 
-		this.tree.updateTreeFromScene(this.home, true);
-	}
+                this.home.add(object);
+                this.transform?.attach(object);
+
+                this.tree.updateTreeFromScene(this.home, true);
+        }
 
 	private isDescendant(object: Object3D, potentialAncestor: Object3D): boolean {
 		let current = object.parent;
@@ -270,11 +278,11 @@ export class DT3DCard extends LitElement {
 		return false;
 	}
 
-	private handleTreeDrop(
-		sourceId: string,
-		targetId: string,
-		position: "before" | "after" | "inside",
-	): void {
+        private handleTreeDrop(
+                sourceId: string,
+                targetId: string,
+                position: "before" | "after" | "inside",
+        ): void {
 		if (!this.home) {
 			return;
 		}
@@ -433,16 +441,46 @@ export class DT3DCard extends LitElement {
                         return;
                 }
 
-                const entityObject = this.pickEntityObjectFromEvent(event);
+                const { object } = this.pickDTObjectFromEvent(event);
 
-                if (entityObject) {
-                        entityObject.handleClick(this.hassInstance);
+                object?.onInteraction({
+                        type: "click",
+                        originalEvent: event,
+                        hass: this.hassInstance,
+                });
+        }
+
+        private handlePointerMove(event: MouseEvent): void {
+                const { object } = this.pickDTObjectFromEvent(event);
+
+                if (object === this.hoveredObject) {
+                        return;
+                }
+
+                if (this.hoveredObject) {
+                        this.hoveredObject.onInteraction({
+                                type: "pointerleave",
+                                originalEvent: event,
+                                hass: this.hassInstance,
+                        });
+                }
+
+                this.hoveredObject = object;
+
+                if (this.hoveredObject) {
+                        this.hoveredObject.onInteraction({
+                                type: "pointerenter",
+                                originalEvent: event,
+                                hass: this.hassInstance,
+                        });
                 }
         }
 
-        private pickEntityObjectFromEvent(event: MouseEvent): EntityObject | null {
+        private pickDTObjectFromEvent(
+                event: MouseEvent,
+        ): { object: DTObject | null; intersection: Intersection<Object3D> | null } {
                 if (!this.canvas || !this.camera || !this.home) {
-                        return null;
+                        return { object: null, intersection: null };
                 }
 
                 const rect = this.canvas.getBoundingClientRect();
@@ -455,18 +493,31 @@ export class DT3DCard extends LitElement {
                         true,
                 );
 
-                const target = intersects[0]?.object ?? null;
-                let current = target as Object3D | null;
+                const intersection = intersects[0] ?? null;
+                let current = intersection?.object ?? null;
 
                 while (current) {
-                        if (current instanceof EntityObject) {
-                                return current;
+                        if (current instanceof DTObject) {
+                                return { object: current, intersection };
                         }
 
                         current = current.parent;
                 }
 
-                return null;
+                return { object: null, intersection };
+        }
+
+        private updateDTObjects(time: number): void {
+                if (!this.home) {
+                        return;
+                }
+
+                this.home.traverse((child) => {
+                        if (child instanceof DTObject) {
+                                child.ensureInitialized();
+                                child.update(time);
+                        }
+                });
         }
 
 	/**
@@ -793,37 +844,54 @@ export class DT3DCard extends LitElement {
 		});
 
 		// Raycaster for object picking
-		this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
-			const rect = this.canvas.getBoundingClientRect();
-			this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-			this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
-			this.raycaster.setFromCamera(this.pointer, this.camera);
+                this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
+                        const { object, intersection } = this.pickDTObjectFromEvent(event);
 
-			const intersects = this.raycaster.intersectObjects(
-				this.home.children,
-				false,
-			);
-			if (intersects.length > 0) {
-				const picked = intersects[0].object as Mesh;
-				this.transform.attach(picked);
-			}
-		});
+                        if (intersection) {
+                                this.transform.attach(intersection.object as Mesh);
+                        }
+
+                        object?.onInteraction({
+                                type: "dblclick",
+                                originalEvent: event,
+                                hass: this.hassInstance,
+                        });
+                });
 
                 this.canvas.addEventListener("click", (event: MouseEvent) =>
                         this.handleCanvasClick(event),
                 );
 
-		const animate = () => {
-			requestAnimationFrame(animate);
-			cube.rotation.x += 0.01;
-			cube.rotation.y += 0.01;
+                this.canvas.addEventListener("mousemove", (event: MouseEvent) =>
+                        this.handlePointerMove(event),
+                );
 
-			// Update controls
-			this.controls.update();
+                this.canvas.addEventListener("mouseleave", (event: MouseEvent) => {
+                        if (!this.hoveredObject) {
+                                return;
+                        }
 
-			this.renderer.render(this.scene, this.camera);
-		};
-		animate();
+                        this.hoveredObject.onInteraction({
+                                type: "pointerleave",
+                                originalEvent: event,
+                                hass: this.hassInstance,
+                        });
+                        this.hoveredObject = null;
+                });
+
+                const animate = (time: number) => {
+                        requestAnimationFrame(animate);
+                        cube.rotation.x += 0.01;
+                        cube.rotation.y += 0.01;
+
+                        this.updateDTObjects(time);
+
+                        // Update controls
+                        this.controls.update();
+
+                        this.renderer.render(this.scene, this.camera);
+                };
+                animate(0);
 
 		const resizeDetector = new ResizeObserver((event) => {
 			const width = event[0].contentRect.width;

--- a/frontend/src/card.ts
+++ b/frontend/src/card.ts
@@ -31,6 +31,7 @@ import { DT3DTree } from "./object-tree.js";
 import { Locale } from "./locale.js";
 import { EntityLight } from "./objects/entity-light.js";
 import { EntitySensor } from "./objects/entity-sensor.js";
+import { EntitySwitch } from "./objects/entity-switch.js";
 import { TextSprite } from "./objects/text-sprite.js";
 
 @customElement("dt3d-card")
@@ -395,11 +396,11 @@ export class DT3DCard extends LitElement {
 		this.measurementHelpers?.clear();
 	}
 
-	private processMeasurementClick(event: MouseEvent): void {
-		if (
-			this.measurementMode === "none" ||
-			!this.canvas ||
-			!this.camera ||
+        private processMeasurementClick(event: MouseEvent): void {
+                if (
+                        this.measurementMode === "none" ||
+                        !this.canvas ||
+                        !this.camera ||
 			!this.home
 		) {
 			return;
@@ -420,8 +421,50 @@ export class DT3DCard extends LitElement {
 			return;
 		}
 
-		this.addMeasurementPoint(point);
-	}
+                this.addMeasurementPoint(point);
+        }
+
+        private handleCanvasClick(event: MouseEvent): void {
+                if (this.measurementMode !== "none") {
+                        this.processMeasurementClick(event);
+                        return;
+                }
+
+                const switchEntity = this.pickSwitchFromEvent(event);
+
+                if (switchEntity) {
+                        switchEntity.toggle(this.hassInstance);
+                }
+        }
+
+        private pickSwitchFromEvent(event: MouseEvent): EntitySwitch | null {
+                if (!this.canvas || !this.camera || !this.home) {
+                        return null;
+                }
+
+                const rect = this.canvas.getBoundingClientRect();
+                this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+                this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+                this.raycaster.setFromCamera(this.pointer, this.camera);
+
+                const intersects = this.raycaster.intersectObjects(
+                        this.home.children,
+                        true,
+                );
+
+                const target = intersects[0]?.object ?? null;
+                let current = target as Object3D | null;
+
+                while (current) {
+                        if (current instanceof EntitySwitch) {
+                                return current;
+                        }
+
+                        current = current.parent;
+                }
+
+                return null;
+        }
 
 	/**
 	 * Add a measurement point based on the current measurement mode.
@@ -763,9 +806,9 @@ export class DT3DCard extends LitElement {
 			}
 		});
 
-		this.canvas.addEventListener("click", (event: MouseEvent) =>
-			this.processMeasurementClick(event),
-		);
+                this.canvas.addEventListener("click", (event: MouseEvent) =>
+                        this.handleCanvasClick(event),
+                );
 
 		const animate = () => {
 			requestAnimationFrame(animate);
@@ -950,15 +993,17 @@ export class DT3DCard extends LitElement {
 		}
 
 		const domain = entityId.split(".")[0];
-		let object: Object3D | null = null;
+                let object: Object3D | null = null;
 
-		if (domain === "sensor") {
-			object = new EntitySensor(entityId, entity);
-		} else if (domain === "light") {
-			object = new EntityLight(entityId, entity);
-		} else {
-			object = this.createDefaultEntityRepresentation(entityId);
-		}
+                if (domain === "sensor") {
+                        object = new EntitySensor(entityId, entity);
+                } else if (domain === "light") {
+                        object = new EntityLight(entityId, entity);
+                } else if (domain === "switch") {
+                        object = new EntitySwitch(entityId, entity);
+                } else {
+                        object = this.createDefaultEntityRepresentation(entityId);
+                }
 
 		if (!object) {
 			return;

--- a/frontend/src/objects/circle-icon-sprite.ts
+++ b/frontend/src/objects/circle-icon-sprite.ts
@@ -2,30 +2,38 @@ import { Sprite, Color, CanvasTexture, SpriteMaterial } from "three";
 
 
 export class CircleIconSprite extends Sprite {
-    public constructor(color: Color | number, size = 0.25) {
-        const canvas = document.createElement("canvas");
-        canvas.width = 128;
-        canvas.height = 128;
-    
-        const ctx = canvas.getContext("2d");
-        if (ctx) {
-            ctx.clearRect(0, 0, canvas.width, canvas.height);
-            ctx.fillStyle =
-                typeof color === "number"
-                    ? `#${color.toString(16).padStart(6, "0")}`
-                    : `#${color.getHexString()}`;
-            ctx.beginPath();
-            ctx.arc(64, 64, 40, 0, Math.PI * 2);
-            ctx.fill();
-            ctx.strokeStyle = "#ffffff";
-            ctx.lineWidth = 4;
-            ctx.stroke();
+        public constructor(color: Color | number, size = 0.25) {
+                const canvas = document.createElement("canvas");
+                canvas.width = 128;
+                canvas.height = 128;
+
+                const ctx = canvas.getContext("2d");
+                if (ctx) {
+                        ctx.clearRect(0, 0, canvas.width, canvas.height);
+                        ctx.fillStyle =
+                                typeof color === "number"
+                                        ? `#${color.toString(16).padStart(6, "0")}`
+                                        : `#${color.getHexString()}`;
+                        ctx.beginPath();
+                        ctx.arc(64, 64, 40, 0, Math.PI * 2);
+                        ctx.fill();
+                        ctx.strokeStyle = "#ffffff";
+                        ctx.lineWidth = 4;
+                        ctx.stroke();
+                }
+
+                const texture = new CanvasTexture(canvas);
+                const material = new SpriteMaterial({ map: texture, transparent: true });
+
+                super(material);
+                this.scale.set(size, size, size);
         }
-    
-        const texture = new CanvasTexture(canvas);
-        const material = new SpriteMaterial({ map: texture, transparent: true });
-        
-        super(material);
-        this.scale.set(size, size, size);
-    }
+
+        public setColor(color: Color | number): void {
+                const newSprite = new CircleIconSprite(color, this.scale.x);
+                if (this.material.map) {
+                        this.material.map.dispose();
+                }
+                this.material = newSprite.material;
+        }
 }

--- a/frontend/src/objects/dt-object.ts
+++ b/frontend/src/objects/dt-object.ts
@@ -1,0 +1,43 @@
+import { Group } from "three";
+
+export type DTInteractionType = "pointerenter" | "pointerleave" | "click" | "dblclick";
+
+export interface DTInteractionEvent {
+        type: DTInteractionType;
+        originalEvent: MouseEvent;
+        hass?: any;
+}
+
+/**
+ * Base class for 3D objects with lifecycle hooks and pointer interactions.
+ */
+export class DTObject extends Group {
+        private initialized = false;
+
+        /**
+         * Called once when the object is first added to the scene.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        public initialize(): void {}
+
+        /**
+         * Called before each render with the current time.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+        public update(_time: number): void {}
+
+        /**
+         * Called when the pointer interacts with the object (enter, leave, click, or double click).
+         */
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+        public onInteraction(_event: DTInteractionEvent): void {}
+
+        public ensureInitialized(): void {
+                if (this.initialized) {
+                        return;
+                }
+
+                this.initialized = true;
+                this.initialize();
+        }
+}

--- a/frontend/src/objects/entity-light.ts
+++ b/frontend/src/objects/entity-light.ts
@@ -1,54 +1,60 @@
 import {
-	Color,
-	Group,
-	PointLight,
+        Color,
+        PointLight,
 } from "three";
 import { TextSprite } from "./text-sprite.js";
 import { CircleIconSprite } from "./circle-icon-sprite.js";
-
+import { EntityObject } from "./entity-object.js";
 
 function getLightColor(entity: any): Color {
-	const rgbColor = entity.attributes?.rgb_color;
-	if (Array.isArray(rgbColor) && rgbColor.length === 3) {
-		return new Color(rgbColor[0] / 255, rgbColor[1] / 255, rgbColor[2] / 255);
-	}
+        const rgbColor = entity.attributes?.rgb_color;
+        if (Array.isArray(rgbColor) && rgbColor.length === 3) {
+                return new Color(rgbColor[0] / 255, rgbColor[1] / 255, rgbColor[2] / 255);
+        }
 
-	const hsColor = entity.attributes?.hs_color;
-	if (Array.isArray(hsColor) && hsColor.length === 2) {
-		const color = new Color();
-		color.setHSL(hsColor[0] / 360, hsColor[1] / 100, 0.5);
-		return color;
-	}
+        const hsColor = entity.attributes?.hs_color;
+        if (Array.isArray(hsColor) && hsColor.length === 2) {
+                const color = new Color();
+                color.setHSL(hsColor[0] / 360, hsColor[1] / 100, 0.5);
+                return color;
+        }
 
-	return new Color(entity.state === "on" ? 0xffffaa : 0x555555);
+        return new Color(entity.state === "on" ? 0xffffaa : 0x555555);
 }
 
-export class EntityLight extends Group {
-	public constructor(entityId: string, entity: any) {
-		super();
-		this.name = entityId;
+export class EntityLight extends EntityObject {
+        private icon: CircleIconSprite;
+        private pointLight: PointLight;
+        private label: TextSprite;
 
-		const color = getLightColor(entity);
+        public constructor(entityId: string, entity: any) {
+                super(entityId);
 
-		const icon = new CircleIconSprite(color, 0.25);
-		icon.position.y = 0.1;
-		this.add(icon);
+                this.icon = new CircleIconSprite(0x555555, 0.25);
+                this.icon.position.y = 0.1;
+                this.add(this.icon);
 
-		const pointLight = new PointLight(
-			color,
-			entity.state === "on" ? 1 : 0,
-			6,
-			2,
-		);
-		pointLight.position.y = 0.4;
-		this.add(pointLight);
+                this.pointLight = new PointLight(0x555555, 0, 6, 2);
+                this.pointLight.position.y = 0.4;
+                this.add(this.pointLight);
 
-		const label = new TextSprite(
-			entity.attributes?.friendly_name ?? entityId,
-			256,
-			96,
-		);
-		label.position.y = 0.6;
-		this.add(label);
-	}
+                this.label = new TextSprite(entity.attributes?.friendly_name ?? entityId, 256, 96);
+                this.label.position.y = 0.6;
+                this.add(this.label);
+
+                this.setEntity(entity);
+        }
+
+        protected updateFromEntity(entity: any): void {
+                const color = getLightColor(entity);
+                this.icon.setColor(color.getHex());
+
+                this.pointLight.color = color;
+                this.pointLight.intensity = entity.state === "on" ? 1 : 0;
+
+                const friendlyName = entity.attributes?.friendly_name ?? this.name;
+                this.label.material.map.dispose();
+                this.label.material.map = new TextSprite(friendlyName, 256, 96).material.map;
+                this.label.material.needsUpdate = true;
+        }
 }

--- a/frontend/src/objects/entity-object.ts
+++ b/frontend/src/objects/entity-object.ts
@@ -1,0 +1,48 @@
+import { Group } from "three";
+
+/**
+ * Base 3D representation for Home Assistant entities.
+ */
+export abstract class EntityObject extends Group {
+        public readonly entityId: string;
+        private entityData: any;
+
+        protected constructor(entityId: string, entity?: any) {
+                super();
+                this.entityId = entityId;
+                this.name = entityId;
+
+                if (entity) {
+                        this.setEntity(entity);
+                }
+        }
+
+        /**
+         * Update the entity data and refresh the visual representation.
+         */
+        public setEntity(entity: any): void {
+                this.entityData = entity;
+                this.updateFromEntity(entity);
+        }
+
+        /**
+         * Retrieve the latest entity state stored on this object.
+         */
+        public getEntity(): any {
+                return this.entityData;
+        }
+
+        /**
+         * Handle pointer click interaction.
+         * Subclasses can override this to perform entity-specific actions.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        public handleClick(_hass: any): void {
+                // Default: no-op
+        }
+
+        /**
+         * Refresh the visuals based on the provided entity data.
+         */
+        protected abstract updateFromEntity(entity: any): void;
+}

--- a/frontend/src/objects/entity-object.ts
+++ b/frontend/src/objects/entity-object.ts
@@ -1,9 +1,9 @@
-import { Group } from "three";
+import { DTInteractionEvent, DTObject } from "./dt-object.js";
 
 /**
  * Base 3D representation for Home Assistant entities.
  */
-export abstract class EntityObject extends Group {
+export abstract class EntityObject extends DTObject {
         public readonly entityId: string;
         private entityData: any;
 
@@ -39,6 +39,12 @@ export abstract class EntityObject extends Group {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         public handleClick(_hass: any): void {
                 // Default: no-op
+        }
+
+        public onInteraction(event: DTInteractionEvent): void {
+                if (event.type === "click") {
+                        this.handleClick((event as any).hass ?? null);
+                }
         }
 
         /**

--- a/frontend/src/objects/entity-sensor.ts
+++ b/frontend/src/objects/entity-sensor.ts
@@ -1,39 +1,37 @@
-import { Group } from "three";
 import { TextSprite } from "./text-sprite.js";
 import { CircleIconSprite } from "./circle-icon-sprite.js";
+import { EntityObject } from "./entity-object.js";
 
 /**
  * Creates a entity sensor representation.
  */
-export class EntitySensor extends Group {
-    public label: TextSprite;
+export class EntitySensor extends EntityObject {
+        public label: TextSprite;
 
-	public constructor(entityId: string, entity: any) {
-		super();
-		this.name = entityId;
+        public constructor(entityId: string, entity: any) {
+                super(entityId);
 
-		const icon = new CircleIconSprite(0x1e90ff, 0.2);
-		icon.position.y = 0.1;
-		this.add(icon);
+                const icon = new CircleIconSprite(0x1e90ff, 0.2);
+                icon.position.y = 0.1;
+                this.add(icon);
 
-		const friendlyName = entity.attributes?.friendly_name ?? entityId;
-		const labelText = `${friendlyName}\n${entity.state}`;
+                this.label = new TextSprite("Loading\n...");
+                this.label.position.y = 0.45;
+                this.add(this.label);
 
-		this.label = new TextSprite(labelText);
-		this.label.position.y = 0.45;
-		this.add(this.label);
-	}
+                this.setEntity(entity);
+        }
 
-    /**
-     * Updates the sensor state.
-     * 
-     * @param entity - The entity data. 
-     */
-    public updateState(entity: any): void {
-        const friendlyName = entity.attributes?.friendly_name ?? this.name;
-        const labelText = `${friendlyName}\n${entity.state}`;
-        this.label.material.map.dispose(); 
-        this.label.material.map = new TextSprite(labelText).material.map;
-        this.label.material.needsUpdate = true; 
-    }
+        /**
+         * Updates the sensor state.
+         *
+         * @param entity - The entity data.
+         */
+        protected updateFromEntity(entity: any): void {
+                const friendlyName = entity.attributes?.friendly_name ?? this.name;
+                const labelText = `${friendlyName}\n${entity.state}`;
+                this.label.material.map.dispose();
+                this.label.material.map = new TextSprite(labelText).material.map;
+                this.label.material.needsUpdate = true;
+        }
 }

--- a/frontend/src/objects/entity-switch.ts
+++ b/frontend/src/objects/entity-switch.ts
@@ -1,0 +1,66 @@
+import { Group, Object3D } from "three";
+import { TextSprite } from "./text-sprite.js";
+import { CircleIconSprite } from "./circle-icon-sprite.js";
+
+export class EntitySwitch extends Group {
+        public entityId: string;
+        public label: TextSprite;
+        private icon: Object3D;
+
+        public constructor(entityId: string, entity: any) {
+                super();
+                this.entityId = entityId;
+                this.name = entityId;
+
+                this.icon = this.createIcon(entity.state === "on");
+                this.icon.position.y = 0.1;
+                this.add(this.icon);
+
+                const friendlyName = entity.attributes?.friendly_name ?? entityId;
+                const labelText = `${friendlyName}\n${entity.state}`;
+
+                this.label = new TextSprite(labelText);
+                this.label.position.y = 0.45;
+                this.add(this.label);
+        }
+
+        public updateState(entity: any): void {
+                const friendlyName = entity.attributes?.friendly_name ?? this.name;
+                const labelText = `${friendlyName}\n${entity.state}`;
+                this.label.material.map.dispose();
+                this.label.material.map = new TextSprite(labelText).material.map;
+                this.label.material.needsUpdate = true;
+
+                this.refreshIcon(entity.state === "on");
+        }
+
+        public async toggle(hass: any): Promise<void> {
+                if (!hass?.callService) {
+                        console.warn("DT3D: Unable to toggle switch; hass instance not available");
+                        return;
+                }
+
+                try {
+                        await hass.callService("switch", "toggle", {
+                                entity_id: this.entityId,
+                        });
+                } catch (error) {
+                        console.error(`DT3D: Failed to toggle switch ${this.entityId}`, error);
+                }
+        }
+
+        private refreshIcon(isOn: boolean): void {
+                if (this.icon) {
+                        this.remove(this.icon);
+                }
+
+                this.icon = this.createIcon(isOn);
+                this.icon.position.y = 0.1;
+                this.add(this.icon);
+        }
+
+        private createIcon(isOn: boolean): Object3D {
+                const color = isOn ? 0x00ff7f : 0x555555;
+                return new CircleIconSprite(color, 0.22);
+        }
+}

--- a/frontend/src/objects/entity-switch.ts
+++ b/frontend/src/objects/entity-switch.ts
@@ -1,30 +1,27 @@
-import { Group, Object3D } from "three";
+import { Object3D } from "three";
 import { TextSprite } from "./text-sprite.js";
 import { CircleIconSprite } from "./circle-icon-sprite.js";
+import { EntityObject } from "./entity-object.js";
 
-export class EntitySwitch extends Group {
-        public entityId: string;
+export class EntitySwitch extends EntityObject {
         public label: TextSprite;
         private icon: Object3D;
 
         public constructor(entityId: string, entity: any) {
-                super();
-                this.entityId = entityId;
-                this.name = entityId;
+                super(entityId);
 
-                this.icon = this.createIcon(entity.state === "on");
+                this.icon = this.createIcon(false);
                 this.icon.position.y = 0.1;
                 this.add(this.icon);
 
-                const friendlyName = entity.attributes?.friendly_name ?? entityId;
-                const labelText = `${friendlyName}\n${entity.state}`;
-
-                this.label = new TextSprite(labelText);
+                this.label = new TextSprite("Loading\n...");
                 this.label.position.y = 0.45;
                 this.add(this.label);
+
+                this.setEntity(entity);
         }
 
-        public updateState(entity: any): void {
+        protected updateFromEntity(entity: any): void {
                 const friendlyName = entity.attributes?.friendly_name ?? this.name;
                 const labelText = `${friendlyName}\n${entity.state}`;
                 this.label.material.map.dispose();
@@ -34,7 +31,7 @@ export class EntitySwitch extends Group {
                 this.refreshIcon(entity.state === "on");
         }
 
-        public async toggle(hass: any): Promise<void> {
+        public async handleClick(hass: any): Promise<void> {
                 if (!hass?.callService) {
                         console.warn("DT3D: Unable to toggle switch; hass instance not available");
                         return;


### PR DESCRIPTION
## Summary
- add a dedicated 3D object for switch entities including icon and label updates
- detect canvas clicks on switch entities and trigger Home Assistant toggle calls
- allow switches to be added to the scene like existing lights and sensors

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936a0ced5088332a41449ca6cf721e7)