### PR TITLE
Highlight active transform tool in sidebar

### DIFF
--- a/frontend/src/components/side-bar/side-bar.css
+++ b/frontend/src/components/side-bar/side-bar.css
@@ -71,6 +71,13 @@ button {
 		color-mix(in srgb, var(--ha-color-neutral-10) 20%, transparent);
 }
 
+.transform-btn.selected {
+	background: color-mix(in srgb, var(--ha-color-primary-60) 80%, var(--ha-color-neutral-05));
+	box-shadow:
+		0 2px 6px color-mix(in srgb, var(--ha-color-primary-60) 35%, transparent),
+		0 0 0 2px color-mix(in srgb, var(--ha-color-primary-60) 50%, transparent) inset;
+}
+
 button:hover {
 	background: var(--ha-color-primary-60);
 	transform: translateY(-1px);

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -11,9 +11,11 @@ export class DT3DSidebar extends LitElement {
 
 	static properties = {
 		collapsed: { type: Boolean, reflect: true },
+		transformTool: { type: String },
 	};
 
 	public collapsed = true;
+	public transformTool: "translate" | "rotate" | "scale" = "translate";
 
 	public disconnectedCallback(): void {
 		super.disconnectedCallback();
@@ -32,7 +34,9 @@ export class DT3DSidebar extends LitElement {
 	 * Change v bnnnn
 	 * @param tool
 	 */
-	private handleTransformSelect(tool: string) {
+	private handleTransformSelect(tool: "translate" | "rotate" | "scale") {
+		this.transformTool = tool;
+
 		this.dispatchEvent(
 			new CustomEvent("transform-tool-selected", {
 				detail: { tool },
@@ -77,13 +81,19 @@ export class DT3DSidebar extends LitElement {
 			</button>
 			<div class="sidebar-section">
 				<div class="sidebar-title">Controls</div>
-				<button @click=${() => this.handleTransformSelect("translate")}>
+				<button
+					class=${`transform-btn ${this.transformTool === "translate" ? "selected" : ""}`.trim()}
+					@click=${() => this.handleTransformSelect("translate")}>
 					<ha-icon icon="mdi:cursor-move"></ha-icon>
 				</button>
-				<button @click=${() => this.handleTransformSelect("rotate")}>
+				<button
+					class=${`transform-btn ${this.transformTool === "rotate" ? "selected" : ""}`.trim()}
+					@click=${() => this.handleTransformSelect("rotate")}>
 					<ha-icon icon="mdi:rotate-right"></ha-icon>
 				</button>
-				<button @click=${() => this.handleTransformSelect("scale")}>
+				<button
+					class=${`transform-btn ${this.transformTool === "scale" ? "selected" : ""}`.trim()}
+					@click=${() => this.handleTransformSelect("scale")}>
 					<ha-icon icon="mdi:resize"></ha-icon>
 				</button>
 			</div>


### PR DESCRIPTION
## Summary
- track the currently selected transform mode in the sidebar component
- visually highlight the active move/rotate/scale buttons to show which tool is selected

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957dbf0169c83328366835e885d4a07)