### PR TITLE
Add CSS3D text labels using CSS3DRenderer

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -20,6 +20,7 @@ import {
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls";
+import { CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer.js";
 import { Sky } from "three/examples/jsm/Addons.js";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
@@ -67,6 +68,11 @@ export class DT3DCard extends LitElement {
 	 * Renderer for the 3D content.
 	 */
 	private renderer: WebGLRenderer = null;
+
+	/**
+	 * Renderer for CSS-based 3D objects.
+	 */
+	private cssRenderer: CSS3DRenderer = null;
 
 	/**
 	 * Controls to navigate the 3D space using input.
@@ -654,6 +660,15 @@ export class DT3DCard extends LitElement {
 		`;
 		this.content.appendChild(this.canvas);
 
+		this.cssRenderer = new CSS3DRenderer();
+		this.cssRenderer.setSize(width, height);
+		this.cssRenderer.domElement.style.position = "absolute";
+		this.cssRenderer.domElement.style.top = "0";
+		this.cssRenderer.domElement.style.left = "0";
+		this.cssRenderer.domElement.style.pointerEvents = "none";
+		this.cssRenderer.domElement.style.borderRadius = "10px";
+		this.content.appendChild(this.cssRenderer.domElement);
+
 		this.scene = new Scene();
 
 		this.measurementHelpers = new Group();
@@ -743,7 +758,6 @@ export class DT3DCard extends LitElement {
 		this.renderer = new WebGLRenderer({ alpha: true, canvas: this.canvas });
 		this.renderer.setSize(width, height, false);
 		this.renderer.setClearColor(0x446644, 1);
-		this.container.appendChild(this.renderer.domElement);
 
 		// Sky
 		const sky = new Sky();
@@ -865,6 +879,7 @@ export class DT3DCard extends LitElement {
 			// Update controls
 			this.controls.update();
 
+			this.cssRenderer.render(this.scene, this.camera);
 			this.renderer.render(this.scene, this.camera);
 		};
 		animate(0);
@@ -883,6 +898,7 @@ export class DT3DCard extends LitElement {
 			this.camera.updateProjectionMatrix();
 
 			this.renderer.setSize(width, height, false);
+			this.cssRenderer.setSize(width, height);
 		});
 		
 		resizeDetector.observe(this.container, { box: "border-box" });

--- a/frontend/src/objects/helpers/css-text.ts
+++ b/frontend/src/objects/helpers/css-text.ts
@@ -1,0 +1,72 @@
+import { CSS3DObject } from "three/examples/jsm/renderers/CSS3DRenderer.js";
+
+export type CSSTextOptions = {
+	className?: string;
+	style?: Partial<CSSStyleDeclaration>;
+};
+
+/**
+ * Text rendered via CSS3DRenderer using DOM elements.
+ */
+export class CSSText extends CSS3DObject {
+	private readonly element: HTMLDivElement;
+
+	public constructor(text: string, options: CSSTextOptions = {}) {
+		const element = document.createElement("div");
+		element.className = options.className ?? "dt3d-css-text";
+		element.textContent = text;
+
+		element.style.position = "absolute";
+		element.style.padding = "4px 8px";
+		element.style.borderRadius = "8px";
+		element.style.background = "rgba(0, 0, 0, 0.7)";
+		element.style.color = "#ffffff";
+		element.style.fontSize = "12px";
+		element.style.fontWeight = "600";
+		element.style.whiteSpace = "nowrap";
+		element.style.pointerEvents = "none";
+		element.style.boxShadow = "0 2px 6px rgba(0, 0, 0, 0.35)";
+
+		super(element);
+
+		this.element = element;
+
+		this.applyStyle(options.style);
+
+		this.onBeforeRender = (_renderer, _scene, camera) => {
+			this.quaternion.copy(camera.quaternion);
+		};
+	}
+
+	/**
+	 * Update the text contents.
+	 *
+	 * @param text - New text.
+	 */
+	public setText(text: string): void {
+		if (this.element.textContent === text) {
+			return;
+		}
+
+		this.element.textContent = text;
+	}
+
+	/**
+	 * Apply custom styles to the DOM element.
+	 *
+	 * @param style - CSS style overrides.
+	 */
+	public applyStyle(style?: Partial<CSSStyleDeclaration>): void {
+		if (!style) {
+			return;
+		}
+
+		Object.entries(style).forEach(([property, value]) => {
+			if (value === undefined) {
+				return;
+			}
+
+			(this.element.style as any)[property] = value;
+		});
+	}
+}

--- a/frontend/src/objects/measurement/angle.ts
+++ b/frontend/src/objects/measurement/angle.ts
@@ -1,6 +1,14 @@
-import { Group, Vector3, Color, Line, BufferGeometry, LineBasicMaterial, MathUtils } from "three";
+import {
+	Group,
+	Vector3,
+	Color,
+	Line,
+	BufferGeometry,
+	LineBasicMaterial,
+	MathUtils,
+} from "three";
 import { getCSSVar } from "../../utils/css-utils";
-import { TextSprite } from "../helpers/text-sprite";
+import { CSSText } from "../helpers/css-text";
 import { Marker } from "./marker";
 
 /**
@@ -42,7 +50,19 @@ export class AngleMeasurement extends Group {
 		const degrees = MathUtils.radToDeg(angle);
 
 		// Label
-		const label = new TextSprite(`${degrees.toFixed(1)}°`);
+		const labelColor = getCSSVar("--ha-color-primary-95").trim() || "#ffffff";
+		const labelBackground =
+			getCSSVar("--ha-color-primary-10").trim() || "rgba(0, 0, 0, 0.7)";
+		const labelBorder =
+			getCSSVar("--ha-color-primary-50").trim() || "rgba(255, 255, 255, 0.3)";
+
+		const label = new CSSText(`${degrees.toFixed(1)}°`, {
+			style: {
+				color: labelColor,
+				background: labelBackground,
+				border: `1px solid ${labelBorder}`,
+			},
+		});
 		label.position.copy(vertex);
 		label.position.y += 0.5;
 		this.add(label);

--- a/frontend/src/objects/measurement/distance.ts
+++ b/frontend/src/objects/measurement/distance.ts
@@ -1,6 +1,13 @@
-import { Group, Vector3, Color, Line, BufferGeometry, LineBasicMaterial } from "three";
+import {
+	Group,
+	Vector3,
+	Color,
+	Line,
+	BufferGeometry,
+	LineBasicMaterial,
+} from "three";
 import { getCSSVar } from "../../utils/css-utils";
-import { TextSprite } from "../helpers/text-sprite";
+import { CSSText } from "../helpers/css-text";
 import { Marker } from "./marker";
 
 /**
@@ -29,7 +36,19 @@ export class DistanceMeasurement extends Group {
 
 		const distance = start.distanceTo(end);
 
-		const label = new TextSprite(`${distance.toFixed(2)}m`);
+		const labelColor = getCSSVar("--ha-color-primary-95").trim() || "#ffffff";
+		const labelBackground =
+			getCSSVar("--ha-color-primary-10").trim() || "rgba(0, 0, 0, 0.7)";
+		const labelBorder =
+			getCSSVar("--ha-color-primary-50").trim() || "rgba(255, 255, 255, 0.3)";
+
+		const label = new CSSText(`${distance.toFixed(2)}m`, {
+			style: {
+				color: labelColor,
+				background: labelBackground,
+				border: `1px solid ${labelBorder}`,
+			},
+		});
 		label.position.copy(start.clone().add(end).multiplyScalar(0.5));
 		label.position.y += 0.2;
 


### PR DESCRIPTION
## Summary
- add a CSSText helper built on CSS3DRenderer for DOM-based 3D labels
- render the CSS3D scene alongside the WebGL output in the card
- switch measurement labels to CSS text with themed styling

## Testing
- npm run build *(fails: missing dependency tippy.js in the current environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f2fd04348332b8f5dac0bc8deb91)