### PR TITLE
Sync double-click selection with tree

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -10,9 +10,9 @@ import {
 	Group,
 	Vector3,
 	Object3D,
-	Intersection,
 	MeshStandardMaterial,
 } from "three";
+import type { Intersection } from "three";
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import type { TransformControls } from "three/examples/jsm/controls/TransformControls";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
@@ -807,7 +807,10 @@ export class DT3DCard extends LitElement {
 		this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
 			const { object, intersection } = this.pickDTObjectFromEvent(event);
 
-			if (intersection) {
+			if (object) {
+				this.transform.attach(object);
+				this.tree?.selectObject(object.uuid);
+			} else if (intersection) {
 				this.transform.attach(intersection.object as Mesh);
 			}
 

--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -408,6 +408,39 @@ export class DT3DTree extends LitElement {
 	}
 
 	/**
+	 * Ensure all ancestors of the node are expanded so the element is visible.
+	 *
+	 * @param id - ID of the node to reveal.
+	 */
+	private expandToNode(id: UUID) {
+		const expanded = new Set(this.expanded);
+		let parentId = this.findParentId(this.tree, id);
+
+		while (parentId) {
+			expanded.add(parentId);
+			parentId = this.findParentId(this.tree, parentId);
+		}
+
+		this.expanded = expanded;
+	}
+
+	/**
+	 * Allow external callers to select a node by ID and sync the inspector.
+	 *
+	 * @param id - ID of the node to select.
+	 */
+	public selectObject(id: UUID | null) {
+		if (!id) {
+			this.selectedId = null;
+			this.selectedObject = null;
+			return;
+		}
+
+		this.expandToNode(id);
+		this.selectNode(id);
+	}
+
+	/**
 	 * Open the context menu, in a specific position.
 	 *
 	 * @param event - Mouse event with the position to open the context menu.

--- a/frontend/src/objects/entity-object.ts
+++ b/frontend/src/objects/entity-object.ts
@@ -1,4 +1,5 @@
-import { DTInteractionEvent, DTObject } from "./dt-object.js";
+import type { DTInteractionEvent } from "./dt-object.js";
+import { DTObject } from "./dt-object.js";
 
 /**
  * Base 3D representation for Home Assistant entities.


### PR DESCRIPTION
## Summary
- expose a public tree selection helper that expands ancestors for visibility
- sync double-click canvas selections with the tree and inspector
- adjust type-only imports to satisfy the build

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959467027dc83329f0880e34c84f865)