### PR TITLE
Persist sidebar and object tree state via local storage

### DIFF
--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -3,6 +3,10 @@ import { customElement, property, state } from "lit/decorators.js";
 import componentStyles from "./object-tree.css?inline";
 import type { Object3D } from "three";
 
+import {
+	readLocalStorageObject,
+	writeLocalStorageObject,
+} from "../../utils/local-storage.js";
 import "./object-inspector.js";
 
 type UUID = string;
@@ -17,6 +21,8 @@ interface TreeNode {
 }
 
 type DropPosition = "before" | "after" | "inside";
+
+const TREE_WIDTH_STORAGE_KEY = "object-tree-width";
 
 @customElement("dt3d-tree")
 export class DT3DTree extends LitElement {
@@ -82,7 +88,8 @@ export class DT3DTree extends LitElement {
 	/**
 	 * Width of the element.
 	 */
-	private width = 220;
+	private width =
+		readLocalStorageObject<number>(TREE_WIDTH_STORAGE_KEY, 220) ?? 220;
 
 	private resizeInitialSize = 0;
 
@@ -96,9 +103,11 @@ export class DT3DTree extends LitElement {
 			return;
 		}
 
-		this.width = this.resizeInitialSize + (this.resizeStartX - event.clientX);
+		const newWidth =
+			this.resizeInitialSize + (this.resizeStartX - event.clientX);
 
-		if (this.width > 50 && this.width < document.body.clientWidth / 2) {
+		if (newWidth > 50 && newWidth < document.body.clientWidth / 2) {
+			this.width = newWidth;
 			this.style.width = this.width + "px";
 		}
 	};
@@ -114,6 +123,8 @@ export class DT3DTree extends LitElement {
 		}
 
 		this.resizing = false;
+
+		writeLocalStorageObject(TREE_WIDTH_STORAGE_KEY, this.width);
 
 		document.body.style.cursor = "";
 		window.removeEventListener("mousemove", this.handleResizeMove);

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -3,10 +3,16 @@ import { customElement } from "lit/decorators.js";
 import tippy, { type Instance, type Props } from "tippy.js";
 import componentStyles from "./side-bar.css?inline";
 import tippyStyles from  "tippy.js/dist/tippy.css?inline";
+import {
+	readLocalStorageObject,
+	writeLocalStorageObject,
+} from "../../utils/local-storage.js";
 
 export type TransformOptions = "translate" | "rotate" | "scale";
 
 export type MeasurementOptions = "distance" | "angle" | "none";
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "sidebar-collapsed";
 
 /**
  * Sidebar contains tools to edit the space.
@@ -23,7 +29,9 @@ export class DT3DSidebar extends LitElement {
 	/**
 	 * Indicates if the sidebar is collapsed or open.
 	 */
-	public collapsed = true;
+	public collapsed =
+		readLocalStorageObject<boolean>(SIDEBAR_COLLAPSED_STORAGE_KEY, true) ??
+		true;
 	
 	/**
 	 * Tooltip instances to preview the option name.
@@ -54,6 +62,8 @@ export class DT3DSidebar extends LitElement {
 	 */
 	private toggleCollapse() {
 		this.collapsed = !this.collapsed;
+
+		writeLocalStorageObject(SIDEBAR_COLLAPSED_STORAGE_KEY, this.collapsed);
 
 		this.requestUpdate();
 	}

--- a/frontend/src/utils/local-storage.ts
+++ b/frontend/src/utils/local-storage.ts
@@ -1,0 +1,44 @@
+const STORAGE_PREFIX = "dt3d-ha-";
+
+const getStorage = (): Storage | null => {
+	if (typeof window === "undefined" || !window.localStorage) {
+		return null;
+	}
+
+	return window.localStorage;
+};
+
+const withPrefix = (key: string) => `${STORAGE_PREFIX}${key}`;
+
+export const writeLocalStorageObject = (key: string, value: unknown): void => {
+	const storage = getStorage();
+	if (!storage) {
+		return;
+	}
+
+	try {
+		storage.setItem(withPrefix(key), JSON.stringify(value));
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.warn("DT3D: Unable to store data in localStorage", error);
+	}
+};
+
+export const readLocalStorageObject = <T>(
+	key: string,
+	defaultValue: T | null = null,
+): T | null => {
+	const storage = getStorage();
+	if (!storage) {
+		return defaultValue;
+	}
+
+	try {
+		const value = storage.getItem(withPrefix(key));
+		return value ? (JSON.parse(value) as T) : defaultValue;
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.warn("DT3D: Unable to read data from localStorage", error);
+		return defaultValue;
+	}
+};


### PR DESCRIPTION
## Summary
- add a local storage helper that prefixes keys for dt3d-ha data
- persist the object tree panel width between sessions using the helper
- remember sidebar collapse state with local storage

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959475c45b4833289d67683b6762a90)