### PR TITLE
Add material color editing to object inspector

### DIFF
--- a/frontend/src/components/object-tree/object-inspector.css
+++ b/frontend/src/components/object-tree/object-inspector.css
@@ -73,6 +73,13 @@ h4 {
 	background: color-mix(in srgb, var(--ha-color-neutral-10) 95%, transparent);
 	color: var(--ha-color-neutral-90);
 }
+.color-field input[type="color"] {
+	width: 100%;
+	height: 36px;
+	padding: 0 6px;
+	box-sizing: border-box;
+	cursor: pointer;
+}
 .placeholder {
 	color: var(--ha-color-neutral-70);
 	font-size: 13px;

--- a/frontend/src/components/object-tree/object-inspector.ts
+++ b/frontend/src/components/object-tree/object-inspector.ts
@@ -1,6 +1,6 @@
 import { LitElement, html, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import type { Object3D } from "three";
+import { Color, Object3D } from "three";
 import { EntityObject } from "../../objects/entity-object.js";
 import componentStyles from "./object-inspector.css?inline";
 
@@ -19,6 +19,23 @@ export class DT3DObjectInspector extends LitElement {
 	 */
 	private isEntityObject(object: Object3D | null): object is EntityObject {
 		return object instanceof EntityObject;
+	}
+
+	/**
+	 * Check if object has a material with a color.
+	 *
+	 * @param object - Object attached to the inspector.
+	 * @returns True if the object has a material color to edit.
+	 */
+	private hasEditableColor(
+		object: Object3D | null,
+	): object is Object3D & { material: { color: Color } } {
+		if (!object || !("material" in object)) {
+			return false;
+		}
+
+		const material = (object as any).material;
+		return Boolean(material?.color && material.color instanceof Color);
 	}
 
 	/**
@@ -76,6 +93,21 @@ export class DT3DObjectInspector extends LitElement {
 		if (Number.isNaN(value)) return;
 
 		this.selectedObject.rotation[axis] = (value * Math.PI) / 180;
+		this.dispatchUpdated();
+		this.requestUpdate();
+	}
+
+	private handleColorChange(event: Event) {
+		if (!this.hasEditableColor(this.selectedObject)) {
+			return;
+		}
+
+		const value = (event.target as HTMLInputElement).value;
+		if (!/^#[0-9a-fA-F]{6}$/.test(value)) {
+			return;
+		}
+
+		this.selectedObject.material.color.set(value);
 		this.dispatchUpdated();
 		this.requestUpdate();
 	}
@@ -154,6 +186,26 @@ export class DT3DObjectInspector extends LitElement {
 		`;
 	}
 
+	private renderMaterialControls() {
+		if (!this.hasEditableColor(this.selectedObject)) {
+			return null;
+		}
+
+		const color = this.selectedObject.material.color;
+
+		return html`
+			<div class="field color-field">
+				<label>Material Color</label>
+				<input
+					type="color"
+					class="color-input"
+					.value=${`#${color.getHexString()}`}
+					@input=${(event: Event) => this.handleColorChange(event)}
+				/>
+			</div>
+		`;
+	}
+
 	private renderEntityDetails() {
 		// Check if object is entity
 		if (!this.isEntityObject(this.selectedObject)) {
@@ -221,7 +273,8 @@ export class DT3DObjectInspector extends LitElement {
 						</div>
 						${this.renderVectorControls("Position", "position")}
 						${this.renderVectorControls("Scale", "scale")}
-						${this.renderRotationControls()} ${this.renderEntityDetails()}
+						${this.renderRotationControls()} ${this.renderMaterialControls()}
+						${this.renderEntityDetails()}
 					`
 				: html`<div class="placeholder">
 						Select an object from the tree to edit its properties.


### PR DESCRIPTION
## Summary
- detect when a selected object has a material color and expose it in the inspector
- add a color input to edit the material color and propagate updates
- style the color control to match existing inspector inputs

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a9e1374948332a169afeda802d066)