### PR TITLE
Add binary entity sprite with icon support

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
 		"format": "prettier --write --use-tabs ."
 	},
 	"dependencies": {
+		"@mdi/js": "~7.4.47",
 		"lit": "~3.3.1",
 		"three": "~0.180.0",
 		"tippy.js": "6.3.7",

--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -1,4 +1,4 @@
-import type { PerspectiveCamera, Scene } from "three";
+import type { Intersection, PerspectiveCamera, Scene } from "three";
 import {
 	Mesh,
 	BoxGeometry,
@@ -10,7 +10,6 @@ import {
 	Group,
 	Vector3,
 	Object3D,
-	Intersection,
 	MeshStandardMaterial,
 } from "three";
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -24,6 +23,7 @@ import { DT3DSidebar } from "./side-bar/side-bar.js";
 import { DT3DTree } from "./object-tree/object-tree.js";
 import { Locale } from "../locale/locale.js";
 import { EntityLight } from "../objects/entity-light.js";
+import { EntityBinary } from "../objects/entity-binary.js";
 import { EntitySensor } from "../objects/entity-sensor.js";
 import { EntitySwitch } from "../objects/entity-switch.js";
 import { EntityObject } from "../objects/entity-object.js";
@@ -880,6 +880,8 @@ export class DT3DCard extends LitElement {
 
 		if (domain === "sensor") {
 			object = new EntitySensor(entityId, entity);
+		} else if (domain === "binary_sensor") {
+			object = new EntityBinary(entityId, entity);
 		} else if (domain === "light") {
 			object = new EntityLight(entityId, entity);
 		} else if (domain === "switch") {

--- a/frontend/src/objects/entity-binary.ts
+++ b/frontend/src/objects/entity-binary.ts
@@ -1,0 +1,87 @@
+import * as mdiIcons from "@mdi/js";
+import { IconSprite } from "./helpers/icon-sprite.js";
+import { EntityObject } from "./entity-object.js";
+import { TextSprite } from "./helpers/text-sprite.js";
+
+const DEFAULT_ICON = mdiIcons.mdiHelpCircleOutline;
+
+/**
+ * Home Assistant binary entity representation.
+ */
+export class EntityBinary extends EntityObject {
+	private iconSprite: IconSprite;
+	private label: TextSprite;
+
+	public constructor(entityId: string, entity: any) {
+		super(entityId);
+
+		const iconPath = EntityBinary.getIconPath(entity?.attributes?.icon);
+		const color = EntityBinary.getStateColor(entity?.state);
+
+		this.iconSprite = new IconSprite(iconPath, color, 0.32);
+		this.iconSprite.position.y = 0.1;
+		this.add(this.iconSprite);
+
+		const friendlyName = entity.attributes?.friendly_name ?? this.name;
+		this.label = new TextSprite(`${friendlyName}\n${entity.state ?? "unknown"}`);
+		this.label.position.y = 0.5;
+		this.add(this.label);
+
+		this.setEntity(entity);
+	}
+
+	protected updateFromEntity(entity: any): void {
+		const friendlyName = entity.attributes?.friendly_name ?? this.name;
+		this.label.setText(`${friendlyName}\n${entity.state ?? "unknown"}`);
+
+		this.iconSprite.setColor(EntityBinary.getStateColor(entity.state));
+		this.iconSprite.setIcon(EntityBinary.getIconPath(entity.attributes?.icon));
+	}
+
+	/**
+	 * Map an HA icon string to an MDI path.
+	 *
+	 * @param icon - Icon name, e.g. "mdi:door".
+	 * @returns SVG path data string.
+	 */
+	private static getIconPath(icon?: string): string {
+		if (!icon || typeof icon !== "string") {
+			return DEFAULT_ICON;
+		}
+
+		const [prefix, name] = icon.split(":");
+		if (prefix !== "mdi" || !name) {
+			return DEFAULT_ICON;
+		}
+
+		const formattedName =
+			"mdi" +
+			name
+				.split("-")
+				.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+				.join("");
+
+		return (mdiIcons as Record<string, string>)[formattedName] ?? DEFAULT_ICON;
+	}
+
+	/**
+	 * Background color based on binary state.
+	 *
+	 * @param state - Entity state string.
+	 * @returns Color as hex number.
+	 */
+	private static getStateColor(state?: string): number {
+		const isOn =
+			state === "on" ||
+			state === "open" ||
+			state === "detected" ||
+			state === "home" ||
+			state === "occupied";
+
+		if (state === "unavailable") {
+			return 0x808080;
+		}
+
+		return isOn ? 0x1e90ff : 0x555555;
+	}
+}

--- a/frontend/src/objects/entity-object.ts
+++ b/frontend/src/objects/entity-object.ts
@@ -1,4 +1,5 @@
-import { DTInteractionEvent, DTObject } from "./dt-object.js";
+import type { DTInteractionEvent } from "./dt-object.js";
+import { DTObject } from "./dt-object.js";
 
 /**
  * Base 3D representation for Home Assistant entities.

--- a/frontend/src/objects/helpers/icon-sprite.ts
+++ b/frontend/src/objects/helpers/icon-sprite.ts
@@ -1,0 +1,98 @@
+import { CanvasTexture, Color, Sprite, SpriteMaterial } from "three";
+
+/**
+ * Sprite that renders an icon centered in a colored circle.
+ */
+export class IconSprite extends Sprite {
+	private iconPath: string;
+	private backgroundColor: Color;
+
+	/**
+	 * @param iconPath - SVG path data for the icon.
+	 * @param backgroundColor - Circle color.
+	 * @param size - Size of the sprite.
+	 */
+	public constructor(iconPath: string, backgroundColor: Color | number, size = 0.35) {
+		const color = new Color(backgroundColor);
+		const texture = IconSprite.createTexture(iconPath, color);
+		const material = new SpriteMaterial({ map: texture, transparent: true });
+
+		super(material);
+
+		this.iconPath = iconPath;
+		this.backgroundColor = color;
+		this.scale.set(size, size, size);
+	}
+
+	/**
+	 * Update the background color of the sprite.
+	 *
+	 * @param color - New circle color.
+	 */
+	public setColor(color: Color | number): void {
+		this.backgroundColor =
+			color instanceof Color ? color : new Color(color);
+		this.refreshTexture();
+	}
+
+	/**
+	 * Update the icon displayed in the sprite.
+	 *
+	 * @param iconPath - SVG path data of the icon.
+	 */
+	public setIcon(iconPath: string): void {
+		this.iconPath = iconPath;
+		this.refreshTexture();
+	}
+
+	private refreshTexture(): void {
+		const texture = IconSprite.createTexture(this.iconPath, this.backgroundColor);
+		const spriteMaterial = this.material as SpriteMaterial;
+
+		if (spriteMaterial.map) {
+			spriteMaterial.map.dispose();
+		}
+
+		spriteMaterial.map = texture;
+		spriteMaterial.needsUpdate = true;
+	}
+
+	private static createTexture(iconPath: string, backgroundColor: Color): CanvasTexture {
+		const canvas = document.createElement("canvas");
+		canvas.width = 128;
+		canvas.height = 128;
+
+		const ctx = canvas.getContext("2d");
+		if (ctx) {
+			ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+			// Circle background.
+			ctx.fillStyle = `#${backgroundColor.getHexString()}`;
+			ctx.beginPath();
+			ctx.arc(64, 64, 42, 0, Math.PI * 2);
+			ctx.fill();
+			ctx.strokeStyle = "#ffffff";
+			ctx.lineWidth = 4;
+			ctx.stroke();
+
+			// Icon
+			if (iconPath) {
+				const path = new Path2D(iconPath);
+				ctx.save();
+				ctx.fillStyle = "#ffffff";
+				ctx.translate(64, 64);
+
+				// Icons are drawn in a 24x24 viewbox; scale to fit the circle.
+				const scale = 2.4;
+				ctx.scale(scale, scale);
+				ctx.translate(-12, -12);
+				ctx.fill(path);
+				ctx.restore();
+			}
+		}
+
+		const texture = new CanvasTexture(canvas);
+		texture.needsUpdate = true;
+		return texture;
+	}
+}


### PR DESCRIPTION
## Summary
- add an IconSprite helper to render MDI paths inside a colored circular sprite
- implement a binary entity representation that colors itself by state and shows the entity icon
- wire binary_sensor entities into the card and add the MDI icon dependency

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab51949a48332be25ecd7771c301e)