### PR TITLE
Add locking safeguards for DTObjects

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -1,4 +1,4 @@
-import type { PerspectiveCamera, Scene } from "three";
+import type { Intersection, PerspectiveCamera, Scene } from "three";
 import {
 	Mesh,
 	BoxGeometry,
@@ -10,7 +10,6 @@ import {
 	Group,
 	Vector3,
 	Object3D,
-	Intersection,
 	MeshStandardMaterial,
 } from "three";
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
@@ -283,7 +282,7 @@ export class DT3DCard extends LitElement {
 		}
 
 		this.space.add(object);
-		this.transform?.attach(object);
+		this.attachTransform(object);
 
 		this.tree.updateTreeFromScene(this.space, true);
 	}
@@ -376,6 +375,31 @@ export class DT3DCard extends LitElement {
 	}
 
 	/**
+	 * Attach transform controls to the target object if it is editable.
+	 *
+	 * Locked DTObjects cannot be edited and will detach the transform helper.
+	 *
+	 * @param target - Object to attach to.
+	 */
+	private attachTransform(target: Object3D | null): void {
+		if (!this.transform) {
+			return;
+		}
+
+		if (!target) {
+			this.transform.detach();
+			return;
+		}
+
+		if (target instanceof DTObject && target.locked) {
+			this.transform.detach();
+			return;
+		}
+
+		this.transform.attach(target);
+	}
+
+	/**
 	 * Delete object from space.
 	 * 
 	 * @param objectId - ID of the object to be delete from the space.
@@ -428,7 +452,7 @@ export class DT3DCard extends LitElement {
 
 		parent.add(clone);
 
-		this.transform?.attach(clone);
+		this.attachTransform(clone);
 		this.tree.updateTreeFromScene(this.space);
 	}
 
@@ -753,7 +777,7 @@ export class DT3DCard extends LitElement {
 			const id = e.detail.id;
 			const object = this.space.getObjectByProperty("uuid", id);
 			if (object) {
-				this.transform.attach(object);
+				this.attachTransform(object);
 			}
 		});
 
@@ -776,11 +800,29 @@ export class DT3DCard extends LitElement {
 			this.cloneObject(id);
 		});
 
+		this.tree.addEventListener("object-updated", (e: any) => {
+			const updatedObject = e.detail?.object as Object3D | null;
+			if (!updatedObject) {
+				return;
+			}
+
+			if (updatedObject instanceof DTObject && updatedObject.locked) {
+				if (this.transform?.object === updatedObject) {
+					this.attachTransform(null);
+				}
+			} else if (this.transform?.object === updatedObject) {
+				this.attachTransform(updatedObject);
+			}
+
+			this.tree.refreshSelectedObject();
+		});
+
 		this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
 			const { object, intersection } = this.pickObjectFromEvent(event);
 			if (intersection) {
-				this.transform.attach(intersection.object as Mesh);
-				this.tree.selectObject(intersection.object.uuid);
+				const target = object ?? (intersection.object as Object3D);
+				this.attachTransform(target);
+				this.tree.selectObject(target.uuid);
 			}
 
 			object?.onInteraction({

--- a/frontend/src/components/object-tree/object-inspector.ts
+++ b/frontend/src/components/object-tree/object-inspector.ts
@@ -2,6 +2,7 @@ import { LitElement, html, unsafeCSS } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Color, Object3D } from "three";
 import { EntityObject } from "../../objects/entity-object.js";
+import { DTObject } from "../../objects/dt-object.js";
 import componentStyles from "./object-inspector.css?inline";
 
 @customElement("dt3d-object-inspector")
@@ -38,6 +39,10 @@ export class DT3DObjectInspector extends LitElement {
 		return Boolean(material?.color && material.color instanceof Color);
 	}
 
+	private isLocked(object: Object3D | null = this.selectedObject): object is DTObject {
+		return object instanceof DTObject && object.locked;
+	}
+
 	/**
 	 *
 	 */
@@ -52,7 +57,7 @@ export class DT3DObjectInspector extends LitElement {
 	}
 
 	private handleNameChange(event: Event) {
-		if (!this.selectedObject) return;
+		if (!this.selectedObject || this.isLocked()) return;
 
 		const value = (event.target as HTMLInputElement).value;
 		this.selectedObject.name = value;
@@ -71,7 +76,7 @@ export class DT3DObjectInspector extends LitElement {
 		axis: "x" | "y" | "z",
 		event: Event,
 	) {
-		if (!this.selectedObject) return;
+		if (!this.selectedObject || this.isLocked()) return;
 
 		const value = parseFloat((event.target as HTMLInputElement).value);
 		if (Number.isNaN(value)) return;
@@ -87,7 +92,7 @@ export class DT3DObjectInspector extends LitElement {
 	}
 
 	private handleRotationChange(axis: "x" | "y" | "z", event: Event) {
-		if (!this.selectedObject) return;
+		if (!this.selectedObject || this.isLocked()) return;
 
 		const value = parseFloat((event.target as HTMLInputElement).value);
 		if (Number.isNaN(value)) return;
@@ -98,7 +103,7 @@ export class DT3DObjectInspector extends LitElement {
 	}
 
 	private handleColorChange(event: Event) {
-		if (!this.hasEditableColor(this.selectedObject)) {
+		if (!this.hasEditableColor(this.selectedObject) || this.isLocked()) {
 			return;
 		}
 
@@ -112,6 +117,16 @@ export class DT3DObjectInspector extends LitElement {
 		this.requestUpdate();
 	}
 
+	private handleLockChange(event: Event) {
+		if (!this.selectedObject || !(this.selectedObject instanceof DTObject)) {
+			return;
+		}
+
+		this.selectedObject.locked = (event.target as HTMLInputElement).checked;
+		this.dispatchUpdated();
+		this.requestUpdate();
+	}
+
 	/**
 	 * Render a vector control element.
 	 *
@@ -119,7 +134,11 @@ export class DT3DObjectInspector extends LitElement {
 	 * @param type - Type (position or scale)
 	 * @returns Rendered element.
 	 */
-	private renderVectorControls(label: string, type: "position" | "scale") {
+	private renderVectorControls(
+		label: string,
+		type: "position" | "scale",
+		locked: boolean,
+	) {
 		if (!this.selectedObject) return null;
 
 		const source =
@@ -139,6 +158,7 @@ export class DT3DObjectInspector extends LitElement {
 									type="number"
 									step="0.01"
 									.value=${source[axis].toFixed(2)}
+									?disabled=${locked}
 									@change=${(event: Event) =>
 										this.handleVectorChange(type, axis, event)}
 								/>
@@ -155,7 +175,7 @@ export class DT3DObjectInspector extends LitElement {
 	 *
 	 * @returns - Renderer element for rotation controls.
 	 */
-	private renderRotationControls() {
+	private renderRotationControls(locked: boolean) {
 		if (!this.selectedObject) {
 			return null;
 		}
@@ -175,6 +195,7 @@ export class DT3DObjectInspector extends LitElement {
 										(this.selectedObject!.rotation[axis] * 180) /
 										Math.PI
 									).toFixed(1)}
+									?disabled=${locked}
 									@change=${(event: Event) =>
 										this.handleRotationChange(axis, event)}
 								/>
@@ -186,7 +207,7 @@ export class DT3DObjectInspector extends LitElement {
 		`;
 	}
 
-	private renderMaterialControls() {
+	private renderMaterialControls(locked: boolean) {
 		if (!this.hasEditableColor(this.selectedObject)) {
 			return null;
 		}
@@ -200,6 +221,7 @@ export class DT3DObjectInspector extends LitElement {
 					type="color"
 					class="color-input"
 					.value=${`#${color.getHexString()}`}
+					?disabled=${locked}
 					@input=${(event: Event) => this.handleColorChange(event)}
 				/>
 			</div>
@@ -255,6 +277,9 @@ export class DT3DObjectInspector extends LitElement {
 	}
 
 	public render() {
+		const locked = this.isLocked();
+		const isDTObject = this.selectedObject instanceof DTObject;
+
 		return html`
 			<h4>Selected Object</h4>
 			${this.selectedObject
@@ -264,16 +289,35 @@ export class DT3DObjectInspector extends LitElement {
 							<input
 								type="text"
 								.value=${this.selectedObject.name || ""}
+								?disabled=${locked}
 								@input=${(event: Event) => this.handleNameChange(event)}
 							/>
 						</div>
+						${isDTObject
+							? html`<div class="field">
+									<label>
+										<input
+											type="checkbox"
+											.checked=${locked}
+											@change=${(event: Event) => this.handleLockChange(event)}
+										/>
+										Locked
+									</label>
+								</div>`
+							: null}
 						<div class="field">
 							<label>UUID</label>
 							<input type="text" .value=${this.selectedObject.uuid} readonly />
 						</div>
-						${this.renderVectorControls("Position", "position")}
-						${this.renderVectorControls("Scale", "scale")}
-						${this.renderRotationControls()} ${this.renderMaterialControls()}
+						${locked
+							? html`<div class="placeholder">
+									This object is locked and cannot be edited.
+								</div>`
+							: null}
+						${this.renderVectorControls("Position", "position", locked)}
+						${this.renderVectorControls("Scale", "scale", locked)}
+						${this.renderRotationControls(locked)}
+						${this.renderMaterialControls(locked)}
 						${this.renderEntityDetails()}
 					`
 				: html`<div class="placeholder">

--- a/frontend/src/components/object-tree/object-tree.css
+++ b/frontend/src/components/object-tree/object-tree.css
@@ -24,6 +24,9 @@
 	white-space: nowrap;
 	width: 100%;
 	color: var(--ha-color-neutral-95);
+	display: flex;
+	align-items: center;
+	gap: 4px;
 }
 
 .tree-node.selected {
@@ -43,6 +46,20 @@
 	cursor: pointer;
 	margin-right: 4px;
 	color: var(--ha-color-primary-60);
+}
+
+.node-label {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.lock-icon {
+	color: var(--ha-color-warning-50, #f0ad4e);
+	width: 14px;
+	height: 14px;
+	font-size: 14px;
+	line-height: 1;
 }
 
 .drop-zone {

--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -2,6 +2,7 @@ import { LitElement, html, unsafeCSS } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import componentStyles from "./object-tree.css?inline";
 import type { Object3D } from "three";
+import { DTObject } from "../../objects/dt-object.js";
 
 import {LocalStorage} from "../../utils/local-storage.js";
 import "./object-inspector.js";
@@ -13,6 +14,8 @@ interface TreeNode {
 	id: UUID;
 	// Display name of the node
 	name: string;
+	// Locked state for DTObjects
+	locked?: boolean;
 	// Children nodes
 	children?: TreeNode[];
 }
@@ -198,6 +201,7 @@ export class DT3DTree extends LitElement {
 		const toTreeNode = (obj: Object3D): TreeNode => ({
 			id: obj.uuid,
 			name: obj.name || obj.type,
+			locked: obj instanceof DTObject ? obj.locked : false,
 			children:
 				obj.children.length > 0 ? obj.children.map(toTreeNode) : undefined,
 		});
@@ -614,7 +618,16 @@ export class DT3DTree extends LitElement {
 											</span>
 										`
 									: html`<span style="display:inline-block;width:16px"></span>`}
-								${node.name}
+								<span class="node-label">
+									${node.name}
+									${node.locked
+										? html`<ha-icon
+												class="lock-icon"
+												icon="mdi:lock"
+												title="Locked"
+											></ha-icon>`
+										: null}
+								</span>
 							</div>
 							${node.children &&
 							node.children.length &&

--- a/frontend/src/objects/dt-object.ts
+++ b/frontend/src/objects/dt-object.ts
@@ -38,6 +38,11 @@ export class DTObject extends Group {
 	public isDTObject: boolean = true;
 
 	/**
+	 * When true, the object cannot be edited via controls or the inspector.
+	 */
+	public locked: boolean = false;
+
+	/**
 	 * Called once when the object is first added to the scene.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -70,5 +75,14 @@ export class DTObject extends Group {
 
 		this.initialized = true;
 		this.initialize();
+	}
+
+	/**
+	 * Copy the object data from another DTObject, including lock state.
+	 */
+	public override copy(source: this, recursive: boolean = true): this {
+		super.copy(source, recursive);
+		this.locked = source.locked;
+		return this;
 	}
 }

--- a/frontend/src/objects/entity-object.ts
+++ b/frontend/src/objects/entity-object.ts
@@ -1,4 +1,4 @@
-import { DTInteractionEvent, DTObject } from "./dt-object.js";
+import { DTObject } from "./dt-object.js";
 
 /**
  * Base 3D representation for Home Assistant entities.


### PR DESCRIPTION
## Summary
- add a locked flag to DTObjects and propagate it during copies
- block transform controls from attaching to locked DTObjects and prefer DTObject targets on selection
- disable inspector editing when an object is locked and clean up unused imports
- allow locking and unlocking from the inspector with a checkbox and detach controls when a selected object becomes locked
- show a locked indicator in the object tree for locked items using HA iconography

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ab4dab69083328303e92f90d313a6)