### PR TITLE
Add `internal` flag to hide objects from tree and ignore pointer events

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -565,18 +565,28 @@ export class DT3DCard extends LitElement {
 			true,
 		);
 
-		const intersection = intersects[0] ?? null;
-		let current = intersection?.object ?? null;
+		for (const intersection of intersects) {
+			let current: Object3D | null = intersection.object;
+			let internalHit = false;
 
-		while (current) {
-			if (current instanceof DTObject) {
-				return { object: current, intersection };
+			while (current) {
+				if (current instanceof DTObject && !current.internal) {
+					return { object: current, intersection };
+				}
+
+				if (current.internal) {
+					internalHit = true;
+				}
+
+				current = current.parent;
 			}
 
-			current = current.parent;
+			if (internalHit) {
+				continue;
+			}
 		}
 
-		return { object: null, intersection };
+		return { object: null, intersection: null };
 	}
 
 

--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -198,15 +198,28 @@ export class DT3DTree extends LitElement {
 
 		console.log("DT3d: Updating tree from scene", scene, reset);
 
-		const toTreeNode = (obj: Object3D): TreeNode => ({
-			id: obj.uuid,
-			name: obj.name || obj.type,
-			locked: obj instanceof DTObject ? obj.locked : false,
-			children:
-				obj.children.length > 0 ? obj.children.map(toTreeNode) : undefined,
-		});
+		const toTreeNode = (obj: Object3D): TreeNode | null => {
+			if (obj.internal) {
+				return null;
+			}
 
-		this.tree = [toTreeNode(scene)];
+			const children =
+				obj.children.length > 0
+					? obj.children
+							.map(toTreeNode)
+							.filter((child): child is TreeNode => child !== null)
+					: [];
+
+			return {
+				id: obj.uuid,
+				name: obj.name || obj.type,
+				locked: obj instanceof DTObject ? obj.locked : false,
+				children: children.length > 0 ? children : undefined,
+			};
+		};
+
+		const root = toTreeNode(scene);
+		this.tree = root ? [root] : [];
 
 		if (this.selectedId) {
 			this.selectedObject =

--- a/frontend/src/objects/dt-object.ts
+++ b/frontend/src/objects/dt-object.ts
@@ -43,6 +43,11 @@ export class DTObject extends Group {
 	public locked: boolean = false;
 
 	/**
+	 * Internal objects are hidden from the object tree and ignored by pointer events.
+	 */
+	public internal: boolean = false;
+
+	/**
 	 * Called once when the object is first added to the scene.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -83,6 +88,7 @@ export class DTObject extends Group {
 	public override copy(source: this, recursive: boolean = true): this {
 		super.copy(source, recursive);
 		this.locked = source.locked;
+		this.internal = source.internal;
 		return this;
 	}
 }

--- a/frontend/src/types/three-internal.d.ts
+++ b/frontend/src/types/three-internal.d.ts
@@ -1,0 +1,11 @@
+import "three";
+
+declare module "three" {
+	interface Object3D {
+		/**
+		 * Marks helper or system objects that should not appear in the object tree
+		 * and must be ignored by pointer interactions.
+		 */
+		internal?: boolean;
+	}
+}


### PR DESCRIPTION
### Motivation
- Introduce a way to mark helper/system objects so they don't clutter the object tree or interfere with user interactions.
- Ensure internal helpers are preserved when objects are cloned or copied.

### Description
- Add an `internal` boolean property to `DTObject` and extend `three`'s `Object3D` via `frontend/src/types/three-internal.d.ts` to allow marking any object as internal.
- Preserve the `internal` flag in `DTObject.copy` so clones inherit the internal status.
- Update `updateTreeFromScene` to skip nodes with `internal` set when building the object tree.
- Update raycast picking (`pickObjectFromEvent`) to ignore intersections that only hit internal objects and only return a `DTObject` when it (or an ancestor) is non-internal.

### Testing
- Ran `npm run build` in `frontend` which completed successfully.
- The project compiles with the new type file and the UI build artifacts were generated successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce7ad97d883329fb825bebc8d38ce)