### PR TITLE
Fix raycast picking for non-internal hits and add `internal` support

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -565,18 +565,30 @@ export class DT3DCard extends LitElement {
 			true,
 		);
 
-		const intersection = intersects[0] ?? null;
-		let current = intersection?.object ?? null;
+		for (const intersection of intersects) {
+			let current: Object3D | null = intersection.object;
+			let internalHit = false;
 
-		while (current) {
-			if (current instanceof DTObject) {
-				return { object: current, intersection };
+			while (current) {
+				if (current instanceof DTObject && !current.internal) {
+					return { object: current, intersection };
+				}
+
+				if (current.internal) {
+					internalHit = true;
+				}
+
+				current = current.parent;
 			}
 
-			current = current.parent;
+			if (internalHit) {
+				continue;
+			}
+
+			return { object: null, intersection };
 		}
 
-		return { object: null, intersection };
+		return { object: null, intersection: null };
 	}
 
 

--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -198,15 +198,28 @@ export class DT3DTree extends LitElement {
 
 		console.log("DT3d: Updating tree from scene", scene, reset);
 
-		const toTreeNode = (obj: Object3D): TreeNode => ({
-			id: obj.uuid,
-			name: obj.name || obj.type,
-			locked: obj instanceof DTObject ? obj.locked : false,
-			children:
-				obj.children.length > 0 ? obj.children.map(toTreeNode) : undefined,
-		});
+		const toTreeNode = (obj: Object3D): TreeNode | null => {
+			if (obj.internal) {
+				return null;
+			}
 
-		this.tree = [toTreeNode(scene)];
+			const children =
+				obj.children.length > 0
+					? obj.children
+							.map(toTreeNode)
+							.filter((child): child is TreeNode => child !== null)
+					: [];
+
+			return {
+				id: obj.uuid,
+				name: obj.name || obj.type,
+				locked: obj instanceof DTObject ? obj.locked : false,
+				children: children.length > 0 ? children : undefined,
+			};
+		};
+
+		const root = toTreeNode(scene);
+		this.tree = root ? [root] : [];
 
 		if (this.selectedId) {
 			this.selectedObject =

--- a/frontend/src/objects/dt-object.ts
+++ b/frontend/src/objects/dt-object.ts
@@ -43,6 +43,11 @@ export class DTObject extends Group {
 	public locked: boolean = false;
 
 	/**
+	 * Internal objects are hidden from the object tree and ignored by pointer events.
+	 */
+	public internal: boolean = false;
+
+	/**
 	 * Called once when the object is first added to the scene.
 	 */
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -83,6 +88,7 @@ export class DTObject extends Group {
 	public override copy(source: this, recursive: boolean = true): this {
 		super.copy(source, recursive);
 		this.locked = source.locked;
+		this.internal = source.internal;
 		return this;
 	}
 }

--- a/frontend/src/types/three-internal.d.ts
+++ b/frontend/src/types/three-internal.d.ts
@@ -1,0 +1,11 @@
+import "three";
+
+declare module "three" {
+	interface Object3D {
+		/**
+		 * Marks helper or system objects that should not appear in the object tree
+		 * and must be ignored by pointer interactions.
+		 */
+		internal?: boolean;
+	}
+}


### PR DESCRIPTION
### Motivation
- Provide a way to mark helper/system objects as hidden from the object tree and ignored by pointer interactions via an `internal` flag.
- Ensure internal helpers are preserved when objects are cloned so their hidden/ignored state persists.
- Restore pointer interactions (including double-click selection) so non-internal mesh intersections are returned even when no `DTObject` ancestor exists.

### Description
- Add an `internal` boolean property to `DTObject` and a declaration augmentation in `frontend/src/types/three-internal.d.ts` to expose `internal` on `three`'s `Object3D`.
- Preserve the `internal` flag in `DTObject.copy` so clones inherit the flag.
- Update `updateTreeFromScene` in `frontend/src/components/object-tree/object-tree.ts` to skip objects with `internal` set when building the tree.
- Fix `pickObjectFromEvent` in `frontend/src/components/card.ts` to return the first non-internal intersection (or the intersection itself when a non-internal mesh is hit) and to continue past purely-internal hits.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ce7ad97d883329fb825bebc8d38ce)