### PR TITLE
Add mesh submenu with full geometry options

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -2,15 +2,33 @@ import type { Intersection, PerspectiveCamera, Scene } from "three";
 import {
 	Mesh,
 	BoxGeometry,
+	CapsuleGeometry,
+	CatmullRomCurve3,
+	CircleGeometry,
+	ConeGeometry,
+	CylinderGeometry,
+	DodecahedronGeometry,
+	ExtrudeGeometry,
+	IcosahedronGeometry,
+	LatheGeometry,
 	MeshBasicMaterial,
-	Raycaster,
-	Vector2,
+	MeshStandardMaterial,
+	Object3D,
+	OctahedronGeometry,
 	PlaneGeometry,
+	PolyhedronGeometry,
+	Raycaster,
+	RingGeometry,
+	Shape,
+	ShapeGeometry,
 	SphereGeometry,
+	Vector2,
 	Group,
 	Vector3,
-	Object3D,
-	MeshStandardMaterial,
+	TetrahedronGeometry,
+	TorusGeometry,
+	TorusKnotGeometry,
+	TubeGeometry,
 } from "three";
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import type { TransformControls } from "three/examples/jsm/controls/TransformControls";
@@ -750,20 +768,137 @@ export class DT3DCard extends LitElement {
 				wireframe: false,
 			});
 
-			if (type === "cube") {
-				const geometry = new BoxGeometry();
-				object = new Mesh(geometry, material);
-				object.name = "Cube";
-			} else if (type === "plane") {
-				const geometry = new PlaneGeometry(1, 1, 1);
-				object = new Mesh(geometry, material);
-				object.rotation.x = -Math.PI / 2;
-				object.position.y = -1;
-				object.name = "Plane";
-			} else if (type === "sphere") {
-				const geometry = new SphereGeometry();
-				object = new Mesh(geometry, material);
-				object.name = "Sphere";
+			const shape = new Shape();
+			shape.moveTo(0, 0);
+			shape.lineTo(0.6, 0);
+			shape.lineTo(0.6, 0.6);
+			shape.lineTo(0, 0.6);
+			shape.lineTo(0, 0);
+
+			switch (type) {
+				case "cube": {
+					object = new Mesh(new BoxGeometry(), material);
+					object.name = "Cube";
+					break;
+				}
+				case "sphere": {
+					object = new Mesh(new SphereGeometry(0.6, 32, 16), material);
+					object.name = "Sphere";
+					break;
+				}
+				case "plane": {
+					object = new Mesh(new PlaneGeometry(1, 1, 1), material);
+					object.rotation.x = -Math.PI / 2;
+					object.position.y = -1;
+					object.name = "Plane";
+					break;
+				}
+				case "capsule": {
+					object = new Mesh(new CapsuleGeometry(0.4, 1, 6, 12), material);
+					object.name = "Capsule";
+					break;
+				}
+				case "circle": {
+					object = new Mesh(new CircleGeometry(0.6, 32), material);
+					object.name = "Circle";
+					break;
+				}
+				case "cone": {
+					object = new Mesh(new ConeGeometry(0.5, 1, 32), material);
+					object.name = "Cone";
+					break;
+				}
+				case "cylinder": {
+					object = new Mesh(new CylinderGeometry(0.4, 0.4, 1, 32), material);
+					object.name = "Cylinder";
+					break;
+				}
+				case "dodecahedron": {
+					object = new Mesh(new DodecahedronGeometry(0.6), material);
+					object.name = "Dodecahedron";
+					break;
+				}
+				case "icosahedron": {
+					object = new Mesh(new IcosahedronGeometry(0.6), material);
+					object.name = "Icosahedron";
+					break;
+				}
+				case "lathe": {
+					const points = [
+						new Vector2(0.0, 0),
+						new Vector2(0.4, 0.2),
+						new Vector2(0.2, 0.6),
+						new Vector2(0.3, 1),
+					];
+					object = new Mesh(new LatheGeometry(points, 24), material);
+					object.name = "Lathe";
+					break;
+				}
+				case "octahedron": {
+					object = new Mesh(new OctahedronGeometry(0.6), material);
+					object.name = "Octahedron";
+					break;
+				}
+				case "polyhedron": {
+					const vertices = [
+						1, 1, 1,
+						-1, -1, 1,
+						-1, 1, -1,
+						1, -1, -1,
+					];
+					const indices = [
+						2, 1, 0,
+						0, 3, 2,
+						1, 3, 0,
+						2, 3, 1,
+					];
+					object = new Mesh(new PolyhedronGeometry(vertices, indices, 0.6, 0), material);
+					object.name = "Polyhedron";
+					break;
+				}
+				case "ring": {
+					object = new Mesh(new RingGeometry(0.3, 0.6, 32), material);
+					object.name = "Ring";
+					break;
+				}
+				case "shape": {
+					object = new Mesh(new ShapeGeometry(shape), material);
+					object.name = "Shape";
+					break;
+				}
+				case "extrude": {
+					object = new Mesh(new ExtrudeGeometry(shape, { depth: 0.2, bevelEnabled: true }), material);
+					object.name = "Extrude";
+					break;
+				}
+				case "tetrahedron": {
+					object = new Mesh(new TetrahedronGeometry(0.6), material);
+					object.name = "Tetrahedron";
+					break;
+				}
+				case "torus": {
+					object = new Mesh(new TorusGeometry(0.5, 0.2, 16, 60), material);
+					object.name = "Torus";
+					break;
+				}
+				case "torusKnot": {
+					object = new Mesh(new TorusKnotGeometry(0.4, 0.15, 80, 12), material);
+					object.name = "Torus Knot";
+					break;
+				}
+				case "tube": {
+					const curve = new CatmullRomCurve3([
+						new Vector3(-0.5, 0, 0),
+						new Vector3(-0.2, 0.5, 0.2),
+						new Vector3(0.2, 0.2, -0.2),
+						new Vector3(0.5, 0.4, 0),
+					]);
+					object = new Mesh(new TubeGeometry(curve, 20, 0.15, 8, false), material);
+					object.name = "Tube";
+					break;
+				}
+				default:
+					break;
 			}
 
 			if (object) {

--- a/frontend/src/components/mesh-options.ts
+++ b/frontend/src/components/mesh-options.ts
@@ -1,0 +1,26 @@
+export type MeshOption = {
+	type: string;
+	label: string;
+};
+
+export const MESH_OPTIONS: MeshOption[] = [
+	{ type: "cube", label: "Cube" },
+	{ type: "sphere", label: "Sphere" },
+	{ type: "plane", label: "Plane" },
+	{ type: "capsule", label: "Capsule" },
+	{ type: "circle", label: "Circle" },
+	{ type: "cone", label: "Cone" },
+	{ type: "cylinder", label: "Cylinder" },
+	{ type: "dodecahedron", label: "Dodecahedron" },
+	{ type: "icosahedron", label: "Icosahedron" },
+	{ type: "lathe", label: "Lathe" },
+	{ type: "octahedron", label: "Octahedron" },
+	{ type: "polyhedron", label: "Polyhedron" },
+	{ type: "ring", label: "Ring" },
+	{ type: "shape", label: "Shape" },
+	{ type: "extrude", label: "Extrude" },
+	{ type: "tetrahedron", label: "Tetrahedron" },
+	{ type: "torus", label: "Torus" },
+	{ type: "torusKnot", label: "Torus Knot" },
+	{ type: "tube", label: "Tube" },
+];

--- a/frontend/src/components/side-bar/side-bar.css
+++ b/frontend/src/components/side-bar/side-bar.css
@@ -82,3 +82,52 @@ button:hover {
 button:active {
 	background: var(--ha-color-primary-40);
 }
+
+.mesh-submenu {
+	margin-bottom: 8px;
+}
+
+.mesh-submenu summary {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 6px;
+	width: 100%;
+	padding: 10px 0;
+	background: var(--ha-color-primary-60);
+	color: var(--ha-color-neutral-95);
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 1em;
+	transition:
+		background 0.2s,
+		transform 0.2s;
+	box-shadow: 0 2px 4px
+		color-mix(in srgb, var(--ha-color-neutral-10) 20%, transparent);
+}
+
+.mesh-submenu summary:hover {
+	background: var(--ha-color-primary-40);
+}
+
+.mesh-submenu[open] summary {
+	background: var(--ha-color-primary-30);
+}
+
+.mesh-submenu summary::-webkit-details-marker {
+	display: none;
+}
+
+.mesh-submenu-items {
+	margin-top: 8px;
+}
+
+.mesh-submenu-items button {
+	font-size: 0.9em;
+	background: var(--ha-color-primary-50);
+}
+
+.mesh-submenu-items button:hover,
+.mesh-submenu-items button:active {
+	background: var(--ha-color-primary-40);
+}

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -4,6 +4,7 @@ import tippy, { type Instance, type Props } from "tippy.js";
 import componentStyles from "./side-bar.css?inline";
 import tippyStyles from  "tippy.js/dist/tippy.css?inline";
 import {LocalStorage} from "../../utils/local-storage.js";
+import { MESH_OPTIONS } from "../mesh-options.js";
 
 export type TransformOptions = "translate" | "rotate" | "scale";
 
@@ -180,24 +181,26 @@ export class DT3DSidebar extends LitElement {
 			</div>
 			<div class="sidebar-section">
 				<div class="sidebar-title">Add</div>
-				<button
-					@click=${() => this.handleAddObject("cube")}
-					data-tooltip="Add cube"
-					aria-label="Add cube">
-					<ha-icon icon="mdi:cube-outline"></ha-icon>
-				</button>
-				<button
-					@click=${() => this.handleAddObject("sphere")}
-					data-tooltip="Add sphere"
-					aria-label="Add sphere">
-					<ha-icon icon="mdi:sphere"></ha-icon>
-				</button>
-				<button
-					@click=${() => this.handleAddObject("plane")}
-					data-tooltip="Add plane"
-					aria-label="Add plane">
-					<ha-icon icon="mdi:square-outline"></ha-icon>
-				</button>
+				<details class="mesh-submenu">
+					<summary
+						data-tooltip="Add mesh"
+						aria-label="Add mesh">
+						<ha-icon icon="mdi:shape-outline"></ha-icon>
+						<span>Mesh</span>
+					</summary>
+					<div class="mesh-submenu-items">
+						${MESH_OPTIONS.map(
+							(option) => html`
+								<button
+									@click=${() => this.handleAddObject(option.type)}
+									data-tooltip=${`Add ${option.label}`}
+									aria-label=${`Add ${option.label}`}>
+									${option.label}
+								</button>
+							`,
+						)}
+					</div>
+				</details>
 				<button
 					@click=${() => this.handleAddObject("upload")}
 					data-tooltip="Upload model"


### PR DESCRIPTION
### Motivation
- Replace the three fixed "cube/sphere/plane" add buttons with a single mesh submenu to expose many Three.js geometry options.  
- Make it easy to add any built-in geometry from Three.js without duplicating UI code.  

### Description
- Add `frontend/src/components/mesh-options.ts` exporting `MESH_OPTIONS` to centralize available mesh types and labels.  
- Replace the individual mesh buttons in `frontend/src/components/side-bar/side-bar.ts` with a `<details>` submenu that renders entries from `MESH_OPTIONS`.  
- Add submenu styling in `frontend/src/components/side-bar/side-bar.css` to match existing UI.  
- Expand mesh creation logic in `frontend/src/components/card.ts` to import and instantiate a broad set of Three.js geometries (e.g. `CapsuleGeometry`, `LatheGeometry`, `PolyhedronGeometry`, `TubeGeometry`, `ExtrudeGeometry`, etc.) with sensible defaults and names.  

### Testing
- Ran `npm install` in `frontend/` which completed successfully.  
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready and served the app.  
- Automated browser check using Playwright loaded `http://127.0.0.1:4173/` and saved a screenshot to `artifacts/mesh-submenu.png` successfully.  
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b2f6446c8332bd90f7023a0af361)