### PR TITLE
Add option to disable transform controls in sidebar

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -753,6 +753,14 @@ export class DT3DCard extends LitElement {
 
 		this.sidebar.addEventListener("transform-tool-selected", (e: any) => {
 			const tool = e.detail.tool;
+			if (tool === "none") {
+				this.transform.enabled = false;
+				this.transform.getHelper().visible = false;
+				return;
+			}
+
+			this.transform.enabled = true;
+			this.transform.getHelper().visible = true;
 			this.transform.setMode(tool);
 		});
 

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -6,7 +6,7 @@ import tippyStyles from  "tippy.js/dist/tippy.css?inline";
 import {LocalStorage} from "../../utils/local-storage.js";
 import { MESH_OPTIONS } from "../mesh-options.js";
 
-export type TransformOptions = "translate" | "rotate" | "scale";
+export type TransformOptions = "translate" | "rotate" | "scale" | "none";
 
 export type MeasurementOptions = "distance" | "angle" | "none";
 
@@ -70,7 +70,7 @@ export class DT3DSidebar extends LitElement {
 	 * Change v bnnnn
 	 * @param tool
 	 */
-	private handleTransformSelect(tool: "translate" | "rotate" | "scale") {
+	private handleTransformSelect(tool: TransformOptions) {
 		this.transformTool = tool;
 
 		this.dispatchEvent(
@@ -177,6 +177,13 @@ export class DT3DSidebar extends LitElement {
 					data-tooltip="Scale object"
 					aria-label="Scale object">
 					<ha-icon icon="mdi:resize"></ha-icon>
+				</button>
+				<button
+          class=${`transform-btn ${this.transformTool === "none" ? "selected" : ""}`.trim()}
+					@click=${() => this.handleTransformSelect("none")}
+					data-tooltip="Disable transform controls"
+					aria-label="Disable transform controls">
+					<ha-icon icon="mdi:cursor-default-outline"></ha-icon>
 				</button>
 			</div>
 			<div class="sidebar-section">


### PR DESCRIPTION
### Motivation
- Provide a quick way to disable the scene transform controls from the sidebar so users can temporarily turn off object manipulation helpers for viewing or other interactions.

### Description
- Added a `none` option to the `TransformOptions` type and a new sidebar button labeled `Disable transform controls` that emits the existing `transform-tool-selected` event with `tool: "none"` when clicked.
- Updated the sidebar handler signature to accept `TransformOptions` (`handleTransformSelect(tool: TransformOptions)`).
- Updated the card event listener for `transform-tool-selected` to disable the `TransformControls` and hide its helper when `tool === "none"`, and to re-enable and show the helper for other tools before calling `setMode`.

### Testing
- Ran `npm install` in `frontend` which completed successfully with no vulnerabilities reported. 
- Started the dev server with `npm run dev` and Vite reported ready and serving the frontend. 
- Executed a Playwright script that loaded the dev server and captured a screenshot of the sidebar with the new control, and the script completed and produced an artifact image successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696779c4bc708332b093a463ebac912f)