### PR TITLE
Add camera mode toggle button (perspective ↔ orthographic)

### DIFF
--- a/frontend/src/components/camera-toggle.ts
+++ b/frontend/src/components/camera-toggle.ts
@@ -1,0 +1,92 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import type { CameraMode } from "./scene.js";
+
+@customElement("dt3d-camera-toggle")
+export class DT3DCameraToggle extends LitElement {
+	@property({ type: String })
+	public mode: CameraMode = "perspective";
+
+	static styles = css`
+		:host {
+			position: absolute;
+			right: 16px;
+			bottom: 16px;
+			z-index: 5;
+			display: block;
+		}
+
+		button {
+			width: 48px;
+			height: 48px;
+			border-radius: 999px;
+			border: none;
+			background: rgba(0, 0, 0, 0.65);
+			color: #ffffff;
+			font-size: 12px;
+			font-weight: 600;
+			letter-spacing: 0.5px;
+			box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			transition: transform 0.15s ease, background 0.15s ease;
+		}
+
+		button:hover {
+			background: rgba(0, 0, 0, 0.8);
+			transform: translateY(-1px);
+		}
+
+		button:active {
+			transform: translateY(0);
+		}
+
+		button:focus-visible {
+			outline: 2px solid rgba(255, 255, 255, 0.9);
+			outline-offset: 2px;
+		}
+	`;
+
+	private handleToggle(): void {
+		const nextMode: CameraMode =
+			this.mode === "perspective" ? "orthographic" : "perspective";
+		this.mode = nextMode;
+		this.dispatchEvent(
+			new CustomEvent("camera-mode-change", {
+				detail: { mode: nextMode },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	private getLabel(): string {
+		return this.mode === "perspective" ? "3D" : "2D";
+	}
+
+	private getAriaLabel(): string {
+		return this.mode === "perspective"
+			? "Switch to orthographic camera"
+			: "Switch to perspective camera";
+	}
+
+	protected render() {
+		return html`
+			<button
+				@click=${this.handleToggle}
+				aria-pressed=${this.mode === "orthographic"}
+				aria-label=${this.getAriaLabel()}
+				title=${this.getAriaLabel()}>
+				${this.getLabel()}
+			</button>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"dt3d-camera-toggle": DT3DCameraToggle;
+	}
+}

--- a/frontend/src/components/camera-toggle.ts
+++ b/frontend/src/components/camera-toggle.ts
@@ -1,53 +1,12 @@
-import { css, html, LitElement } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { CameraMode } from "./scene.js";
+import "./floating-button.js";
 
 @customElement("dt3d-camera-toggle")
 export class DT3DCameraToggle extends LitElement {
 	@property({ type: String })
 	public mode: CameraMode = "perspective";
-
-	static styles = css`
-		:host {
-			position: absolute;
-			right: 16px;
-			bottom: 16px;
-			z-index: 5;
-			display: block;
-		}
-
-		button {
-			width: 48px;
-			height: 48px;
-			border-radius: 999px;
-			border: none;
-			background: rgba(0, 0, 0, 0.65);
-			color: #ffffff;
-			font-size: 12px;
-			font-weight: 600;
-			letter-spacing: 0.5px;
-			box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
-			cursor: pointer;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			transition: transform 0.15s ease, background 0.15s ease;
-		}
-
-		button:hover {
-			background: rgba(0, 0, 0, 0.8);
-			transform: translateY(-1px);
-		}
-
-		button:active {
-			transform: translateY(0);
-		}
-
-		button:focus-visible {
-			outline: 2px solid rgba(255, 255, 255, 0.9);
-			outline-offset: 2px;
-		}
-	`;
 
 	private handleToggle(): void {
 		const nextMode: CameraMode =
@@ -72,15 +31,18 @@ export class DT3DCameraToggle extends LitElement {
 			: "Switch to perspective camera";
 	}
 
+	private handleFloatingClick(): void {
+		this.handleToggle();
+	}
+
 	protected render() {
 		return html`
-			<button
-				@click=${this.handleToggle}
-				aria-pressed=${this.mode === "orthographic"}
-				aria-label=${this.getAriaLabel()}
-				title=${this.getAriaLabel()}>
+			<dt3d-floating-button
+				@floating-button-click=${this.handleFloatingClick}
+				ariaLabel=${this.getAriaLabel()}
+				titleText=${this.getAriaLabel()}>
 				${this.getLabel()}
-			</button>
+			</dt3d-floating-button>
 		`;
 	}
 }

--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -1,4 +1,4 @@
-import type { Intersection, PerspectiveCamera, Scene } from "three";
+import type { Camera, Intersection, Scene } from "three";
 import {
 	Mesh,
 	BoxGeometry,
@@ -53,9 +53,11 @@ import { AngleMeasurement } from "../objects/measurement/angle.js";
 import { DistanceMeasurement } from "../objects/measurement/distance.js";
 import { ConnectionStatus } from "./connection-status/connection-status.js";
 import { SceneManager } from "./scene.js";
+import type { CameraMode } from "./scene.js";
 import { RendererManager } from "./renderer.js";
 import { createMeshObject } from "./mesh-options.js";
 import { EntityGeneric } from "../objects/entity-generic.js";
+import { DT3DCameraToggle } from "./camera-toggle.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -82,7 +84,7 @@ export class DT3DCard extends LitElement {
 	/**
 	 * Viewport into the 3D space.
 	 */
-	private camera: PerspectiveCamera = null;
+	private camera: Camera = null;
 
 	/**
 	 * Renderer for the 3D content.
@@ -750,6 +752,18 @@ export class DT3DCard extends LitElement {
 			this.scene,
 			width,
 		);
+
+		const cameraToggle = document.createElement(
+			"dt3d-camera-toggle",
+		) as DT3DCameraToggle;
+		cameraToggle.mode = this.sceneManager.getCameraMode();
+		cameraToggle.addEventListener("camera-mode-change", (event: Event) => {
+			const { mode } = (event as CustomEvent<{ mode: CameraMode }>).detail;
+			this.sceneManager.setCameraMode(mode);
+			this.camera = this.sceneManager.camera;
+			this.rendererManager.setCamera(this.camera);
+		});
+		this.content.appendChild(cameraToggle);
 
 		this.sidebar.addEventListener("transform-tool-selected", (e: any) => {
 			const tool = e.detail.tool;

--- a/frontend/src/components/floating-button.ts
+++ b/frontend/src/components/floating-button.ts
@@ -1,0 +1,80 @@
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("dt3d-floating-button")
+export class DT3DFloatingButton extends LitElement {
+	@property({ type: String })
+	public ariaLabel = "";
+
+	@property({ type: String })
+	public titleText = "";
+
+	static styles = css`
+		:host {
+			position: absolute;
+			right: 16px;
+			bottom: 16px;
+			z-index: 5;
+			display: block;
+		}
+
+		button {
+			width: 48px;
+			height: 48px;
+			border-radius: 999px;
+			border: none;
+			background: rgba(0, 0, 0, 0.65);
+			color: #ffffff;
+			font-size: 12px;
+			font-weight: 600;
+			letter-spacing: 0.5px;
+			box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			transition: transform 0.15s ease, background 0.15s ease;
+		}
+
+		button:hover {
+			background: rgba(0, 0, 0, 0.8);
+			transform: translateY(-1px);
+		}
+
+		button:active {
+			transform: translateY(0);
+		}
+
+		button:focus-visible {
+			outline: 2px solid rgba(255, 255, 255, 0.9);
+			outline-offset: 2px;
+		}
+	`;
+
+	private handleClick(event: MouseEvent): void {
+		this.dispatchEvent(
+			new CustomEvent("floating-button-click", {
+				detail: { event },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	protected render() {
+		return html`
+			<button
+				@click=${this.handleClick}
+				aria-label=${this.ariaLabel}
+				title=${this.titleText}>
+				<slot></slot>
+			</button>
+		`;
+	}
+}
+
+declare global {
+	interface HTMLElementTagNameMap {
+		"dt3d-floating-button": DT3DFloatingButton;
+	}
+}

--- a/frontend/src/components/renderer.ts
+++ b/frontend/src/components/renderer.ts
@@ -1,4 +1,4 @@
-import type { PerspectiveCamera, Scene } from "three";
+import type { Camera, Scene } from "three";
 import { WebGLRenderer } from "three";
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { CSS3DRenderer } from "three/examples/jsm/renderers/CSS3DRenderer.js";
@@ -25,7 +25,7 @@ export class RendererManager {
 	/**
 	 * Camera to view into the scene.
 	 */
-	public camera: PerspectiveCamera;
+	public camera: Camera;
 
 	/**
 	 * Control object used to move around the scene.
@@ -37,7 +37,7 @@ export class RendererManager {
 	 */
 	private running: boolean = false;
 
-	constructor(camera: PerspectiveCamera, canvas: HTMLCanvasElement, controls: OrbitControls, cssElement: HTMLElement, height: number, scene: Scene, width: number) {
+	constructor(camera: Camera, canvas: HTMLCanvasElement, controls: OrbitControls, cssElement: HTMLElement, height: number, scene: Scene, width: number) {
 		this.scene = scene;
 		this.camera = camera;
 		this.controls = controls;
@@ -92,5 +92,9 @@ export class RendererManager {
 	public resize(width: number, height: number): void {
 		this.renderer.setSize(width, height, false);
 		this.cssRenderer.setSize(width, height);
+	}
+
+	public setCamera(camera: Camera): void {
+		this.camera = camera;
 	}
 }

--- a/frontend/src/components/scene.ts
+++ b/frontend/src/components/scene.ts
@@ -3,6 +3,7 @@ import {
 	BoxGeometry,
 	DirectionalLight,
 	Group,
+	OrthographicCamera,
 	MathUtils,
 	Mesh,
 	MeshStandardMaterial,
@@ -14,9 +15,9 @@ import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { TransformControls } from "three/examples/jsm/controls/TransformControls";
 import { Sky } from "three/examples/jsm/Addons.js";
 
-interface SceneManagerOptions {
+export type CameraMode = "perspective" | "orthographic";
 
-}
+interface SceneManagerOptions {}
 
 /**
  * SceneManager handles scene creation and camera/controls setup.
@@ -30,7 +31,22 @@ export class SceneManager {
 	/**
 	 * Camera used to visualize content.
 	 */
-	public camera: PerspectiveCamera;
+	public camera: PerspectiveCamera | OrthographicCamera;
+
+	/**
+	 * Current camera mode.
+	 */
+	private cameraMode: CameraMode = "perspective";
+
+	private perspectiveCamera: PerspectiveCamera;
+
+	private orthographicCamera: OrthographicCamera;
+
+	private width: number;
+
+	private height: number;
+
+	private orthographicFrustumSize = 6;
 
 	/**
 	 * Space being visualized currently.
@@ -57,8 +73,17 @@ export class SceneManager {
 	constructor(canvas: HTMLCanvasElement, height: number, width: number,) {
 		this.scene = new Scene();
 
-		this.camera = new PerspectiveCamera(75, width / height, 0.1, 10000);
-		this.camera.position.z = 3;
+		this.width = width;
+		this.height = height;
+
+		this.perspectiveCamera = new PerspectiveCamera(75, width / height, 0.1, 10000);
+		this.perspectiveCamera.position.z = 3;
+
+		this.orthographicCamera = new OrthographicCamera(-1, 1, 1, -1, 0.1, 10000);
+		this.updateOrthographicCameraSize(width, height);
+		this.orthographicCamera.position.copy(this.perspectiveCamera.position);
+
+		this.camera = this.perspectiveCamera;
 
 		this.measurements = new Group();
 		this.scene.add(this.measurements);
@@ -105,8 +130,56 @@ export class SceneManager {
 	 * @param height - Height in px
 	 */
 	public updateSize(width: number, height: number): void {
-		this.camera.aspect = width / height;
-		this.camera.updateProjectionMatrix();
+		this.width = width;
+		this.height = height;
+
+		this.perspectiveCamera.aspect = width / height;
+		this.perspectiveCamera.updateProjectionMatrix();
+		this.updateOrthographicCameraSize(width, height);
+	}
+
+	public setCameraMode(mode: CameraMode): void {
+		if (mode === this.cameraMode) {
+			return;
+		}
+
+		const previousCamera = this.camera;
+		this.cameraMode = mode;
+		this.camera =
+			mode === "perspective" ? this.perspectiveCamera : this.orthographicCamera;
+
+		this.camera.position.copy(previousCamera.position);
+		this.camera.quaternion.copy(previousCamera.quaternion);
+		this.camera.updateMatrixWorld();
+
+		this.controls.object = this.camera;
+		this.controls.update();
+
+		this.transform.camera = this.camera;
+		this.transform.updateMatrixWorld();
+	}
+
+	public toggleCameraMode(): CameraMode {
+		const nextMode: CameraMode =
+			this.cameraMode === "perspective" ? "orthographic" : "perspective";
+		this.setCameraMode(nextMode);
+		return this.cameraMode;
+	}
+
+	public getCameraMode(): CameraMode {
+		return this.cameraMode;
+	}
+
+	private updateOrthographicCameraSize(width: number, height: number): void {
+		const aspect = width / height;
+		const halfHeight = this.orthographicFrustumSize / 2;
+		const halfWidth = halfHeight * aspect;
+
+		this.orthographicCamera.left = -halfWidth;
+		this.orthographicCamera.right = halfWidth;
+		this.orthographicCamera.top = halfHeight;
+		this.orthographicCamera.bottom = -halfHeight;
+		this.orthographicCamera.updateProjectionMatrix();
 	}
 
 	/**


### PR DESCRIPTION
### Motivation
- Provide a floating UI control to let users switch between perspective and orthographic views for different viewing modes (3D / 2D).

### Description
- Add a new floating component `dt3d-camera-toggle` that emits a `camera-mode-change` event and shows a compact `3D`/`2D` button (`frontend/src/components/camera-toggle.ts`).
- Extend `SceneManager` to maintain both a `PerspectiveCamera` and an `OrthographicCamera`, expose `setCameraMode`, `toggleCameraMode`, and `getCameraMode`, and keep camera transforms and controls synced when switching modes (`frontend/src/components/scene.ts`).
- Make `RendererManager` accept a generic `Camera` type and add `setCamera` so the renderer uses the active camera (`frontend/src/components/renderer.ts`).
- Wire the new toggle into the card UI: create the `dt3d-camera-toggle` element in the card, handle its `camera-mode-change` events to call `SceneManager.setCameraMode`, update the card `camera` reference, and call `RendererManager.setCamera` (`frontend/src/components/card.ts`).

### Testing
- Started the dev server with `npm run dev` and confirmed the app served successfully (Vite ready). (succeeded)
- Launched a Playwright script to load the local dev page and capture a screenshot of the toggle; the script produced `artifacts/camera-toggle.png` indicating the UI rendered. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d195b27f08332aefc33e206054f9a)