### PR TITLE
Extract Space API client to utils and integrate with card sync logic

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -58,12 +58,8 @@ import { RendererManager } from "./renderer.js";
 import { createMeshObject } from "./mesh-options.js";
 import { EntityGeneric } from "../objects/entity-generic.js";
 import { DT3DCameraToggle } from "./camera-toggle.js";
-import {
-	SpaceApi,
-	type SpaceResponse,
-	type ObjectInstancePayload,
-	type ObjectInstanceResponse,
-} from "../utils/space-api.js";
+import { SpaceApi } from "../utils/space-api.js";
+import { SpaceSync } from "../utils/space-sync.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -145,24 +141,14 @@ export class DT3DCard extends LitElement {
 	private raycaster: Raycaster = new Raycaster();
 
 	/**
-	 * Active space ID loaded from the API.
-	 */
-	private activeSpaceId: string | null = null;
-
-	/**
 	 * API client for fetching/saving spaces and objects.
 	 */
 	private apiClient: SpaceApi | null = null;
 
 	/**
-	 * Map of three.js object UUIDs to API object IDs.
+	 * API sync helper for spaces and objects.
 	 */
-	private objectApiIds: Map<string, string> = new Map();
-
-	/**
-	 * Flag to avoid syncing while loading from API.
-	 */
-	private isSyncingFromApi: boolean = false;
+	private spaceSync: SpaceSync | null = null;
 
 	/**
 	 * Normalized pointer position.
@@ -335,7 +321,7 @@ export class DT3DCard extends LitElement {
 
 		this.tree.updateTreeFromScene(this.space, true);
 
-		void this.syncObjectHierarchyCreate(object);
+		void this.spaceSync?.syncObjectHierarchyCreate(object);
 	}
 
 	/**
@@ -424,7 +410,7 @@ export class DT3DCard extends LitElement {
 
 		this.tree.updateTreeFromScene();
 
-		void this.syncObjectUpdate(source);
+		void this.spaceSync?.syncObjectUpdate(source);
 	}
 
 	/**
@@ -482,7 +468,7 @@ export class DT3DCard extends LitElement {
 
 		this.tree.updateTreeFromScene(this.space, true);
 
-		void this.syncObjectDelete(target);
+		void this.spaceSync?.syncObjectDelete(target);
 	}
 
 	/**
@@ -509,7 +495,7 @@ export class DT3DCard extends LitElement {
 		this.attachTransform(clone);
 		this.tree.updateTreeFromScene(this.space);
 
-		void this.syncObjectHierarchyCreate(clone);
+		void this.spaceSync?.syncObjectHierarchyCreate(clone);
 	}
 
 	/**
@@ -781,7 +767,7 @@ export class DT3DCard extends LitElement {
 		this.sceneManager.transform.addEventListener("objectChange", () => {
 			this.tree.refreshSelectedObject();
 			if (this.transform?.object) {
-				void this.syncObjectUpdate(this.transform.object);
+				void this.spaceSync?.syncObjectUpdate(this.transform.object);
 			}
 		});
 
@@ -855,7 +841,15 @@ export class DT3DCard extends LitElement {
 
 
 		this.tree.scene = this.space;
-		void this.initializeSpaceFromApi();
+		this.spaceSync = new SpaceSync({
+			apiClient: this.getApiClient(),
+			sceneManager: this.sceneManager,
+			space: this.space,
+			tree: this.tree,
+			resolveMeshType: (object) => this.resolveMeshType(object),
+			createEntityObject: (entityId) => this.createEntityObject(entityId),
+		});
+		void this.spaceSync.initializeSpaceFromApi();
 
 		// Listen for selection events from the tree
 		this.tree.addEventListener("object-selected", (e: any) => {
@@ -900,7 +894,7 @@ export class DT3DCard extends LitElement {
 			}
 
 			this.tree.refreshSelectedObject();
-			void this.syncObjectUpdate(updatedObject);
+			void this.spaceSync?.syncObjectUpdate(updatedObject);
 		});
 
 		this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
@@ -1041,152 +1035,6 @@ export class DT3DCard extends LitElement {
 		return this.apiClient;
 	}
 
-	private clearSpace(): void {
-		if (!this.space) {
-			return;
-		}
-
-		this.space.clear();
-		this.objectApiIds.clear();
-	}
-
-	private async initializeSpaceFromApi(): Promise<void> {
-		this.isSyncingFromApi = true;
-
-		try {
-			const apiClient = this.getApiClient();
-			const spaces = await apiClient.listSpaces();
-			let space = spaces[0];
-
-			if (!space) {
-				space = await apiClient.createSpace(
-					"Default Space",
-					"Auto-created space",
-				);
-			}
-
-			this.activeSpaceId = space.id;
-
-			const instances = await apiClient.listObjects(space.id);
-
-			if (instances.length === 0) {
-				this.clearSpace();
-				this.sceneManager.createDefaultScene();
-				this.tree.updateTreeFromScene(this.space, true);
-				this.isSyncingFromApi = false;
-				await this.syncAllObjectsToApi();
-				return;
-			}
-
-			this.loadObjectsFromApi(instances);
-			this.tree.updateTreeFromScene(this.space, true);
-		} catch (error) {
-			console.error("DT3D: Failed to load spaces from API", error);
-			this.clearSpace();
-			this.sceneManager.createDefaultScene();
-			this.tree.updateTreeFromScene(this.space, true);
-		} finally {
-			this.isSyncingFromApi = false;
-		}
-	}
-
-	private loadObjectsFromApi(instances: ObjectInstanceResponse[]): void {
-		this.clearSpace();
-
-		const objectsById = new Map<string, Object3D>();
-
-		for (const instance of instances) {
-			const object = this.createObjectFromInstance(instance);
-			if (!object) {
-				continue;
-			}
-
-			object.userData.apiId = instance.id;
-			this.objectApiIds.set(object.uuid, instance.id);
-			objectsById.set(instance.id, object);
-		}
-
-		for (const instance of instances) {
-			const object = objectsById.get(instance.id);
-			if (!object) {
-				continue;
-			}
-
-			const parentId = instance.parent_id;
-			const parent = parentId ? objectsById.get(parentId) : null;
-			if (parent) {
-				parent.add(object);
-			} else {
-				this.space.add(object);
-			}
-
-			if (object instanceof DTObject) {
-				object.init();
-			}
-		}
-	}
-
-	private createObjectFromInstance(instance: ObjectInstanceResponse): Object3D | null {
-		const data = instance.data ?? {};
-		let object: Object3D | null = null;
-
-		if (instance.type === "mesh") {
-			const meshType = data.meshType as string | undefined;
-			if (!meshType) {
-				return null;
-			}
-
-			const color = typeof data.color === "string" ? parseInt(data.color, 16) : 0xffffff;
-			const material = new MeshStandardMaterial({ color });
-			object = createMeshObject(meshType, material);
-			if (object) {
-				object.userData.meshType = meshType;
-			}
-		} else if (instance.type === "entity") {
-			const entityId = data.entityId as string | undefined;
-			if (!entityId) {
-				return null;
-			}
-
-			object = this.createEntityObject(entityId);
-			if (object) {
-				object.userData.entityId = entityId;
-			}
-		} else if (instance.type === "group") {
-			object = new Group();
-		}
-
-		if (!object) {
-			return null;
-		}
-
-		object.name = instance.name || object.name;
-		this.applyObjectTransform(object, data);
-
-		if (object instanceof DTObject && typeof data.locked === "boolean") {
-			object.locked = data.locked;
-		}
-
-		return object;
-	}
-
-	private applyObjectTransform(object: Object3D, data: Record<string, any>): void {
-		const position = data.position as { x?: number; y?: number; z?: number } | undefined;
-		if (position) {
-			object.position.set(position.x ?? 0, position.y ?? 0, position.z ?? 0);
-		}
-
-		const rotation = data.rotation as { x?: number; y?: number; z?: number } | undefined;
-		if (rotation) {
-			object.rotation.set(rotation.x ?? 0, rotation.y ?? 0, rotation.z ?? 0);
-		}
-
-		const scale = data.scale as { x?: number; y?: number; z?: number } | undefined;
-		if (scale) {
-			object.scale.set(scale.x ?? 1, scale.y ?? 1, scale.z ?? 1);
-		}
-	}
-
 	private resolveMeshType(object: Object3D): string | null {
 		const meshType = object.userData.meshType as string | undefined;
 		if (meshType) {
@@ -1196,32 +1044,46 @@ export class DT3DCard extends LitElement {
 		if (object instanceof Mesh) {
 			switch (object.geometry?.type) {
 				case "BoxGeometry":
+				case "BoxBufferGeometry":
 					return "cube";
 				case "SphereGeometry":
+				case "SphereBufferGeometry":
 					return "sphere";
 				case "PlaneGeometry":
+				case "PlaneBufferGeometry":
 					return "plane";
 				case "CapsuleGeometry":
+				case "CapsuleBufferGeometry":
 					return "capsule";
 				case "CircleGeometry":
+				case "CircleBufferGeometry":
 					return "circle";
 				case "ConeGeometry":
+				case "ConeBufferGeometry":
 					return "cone";
 				case "CylinderGeometry":
+				case "CylinderBufferGeometry":
 					return "cylinder";
 				case "DodecahedronGeometry":
+				case "DodecahedronBufferGeometry":
 					return "dodecahedron";
 				case "IcosahedronGeometry":
+				case "IcosahedronBufferGeometry":
 					return "icosahedron";
 				case "OctahedronGeometry":
+				case "OctahedronBufferGeometry":
 					return "octahedron";
 				case "RingGeometry":
+				case "RingBufferGeometry":
 					return "ring";
 				case "TetrahedronGeometry":
+				case "TetrahedronBufferGeometry":
 					return "tetrahedron";
 				case "TorusGeometry":
+				case "TorusBufferGeometry":
 					return "torus";
 				case "TorusKnotGeometry":
+				case "TorusKnotBufferGeometry":
 					return "torusKnot";
 				default:
 					return null;
@@ -1229,182 +1091,6 @@ export class DT3DCard extends LitElement {
 		}
 
 		return null;
-	}
-
-	private async syncAllObjectsToApi(): Promise<void> {
-		if (!this.space) {
-			return;
-		}
-
-		for (const child of this.space.children) {
-			await this.syncObjectHierarchyCreate(child);
-		}
-	}
-
-	private shouldPersistObject(object: Object3D): boolean {
-		if (!this.space || object === this.space) {
-			return false;
-		}
-
-		if ((object as any).internal === true) {
-			return false;
-		}
-
-		return object.parent === this.space || this.isDescendant(object, this.space);
-	}
-
-	private buildObjectPayload(object: Object3D): ObjectInstancePayload | null {
-		if (!this.activeSpaceId || !this.shouldPersistObject(object)) {
-			return null;
-		}
-
-		let type = "group";
-		const data: Record<string, any> = {
-			position: {
-				x: object.position.x,
-				y: object.position.y,
-				z: object.position.z,
-			},
-			rotation: {
-				x: object.rotation.x,
-				y: object.rotation.y,
-				z: object.rotation.z,
-			},
-			scale: {
-				x: object.scale.x,
-				y: object.scale.y,
-				z: object.scale.z,
-			},
-		};
-
-		if (object instanceof EntityObject) {
-			type = "entity";
-			data.entityId = object.entityId;
-		} else {
-			const meshType = this.resolveMeshType(object);
-			if (meshType) {
-				type = "mesh";
-				data.meshType = meshType;
-
-				const material = (object as any).material;
-				if (material?.color?.getHexString) {
-					data.color = material.color.getHexString();
-				}
-			}
-		}
-
-		if (object instanceof DTObject) {
-			data.locked = object.locked;
-		}
-
-		const parent = object.parent && object.parent !== this.space ? object.parent : null;
-		const parentId = parent ? this.getObjectApiId(parent) : null;
-
-		return {
-			name: object.name || "Object",
-			type,
-			data,
-			parent_id: parentId ?? null,
-		};
-	}
-
-	private getObjectApiId(object: Object3D): string | undefined {
-		return this.objectApiIds.get(object.uuid) ?? object.userData.apiId;
-	}
-
-	private setObjectApiId(object: Object3D, id: string): void {
-		this.objectApiIds.set(object.uuid, id);
-		object.userData.apiId = id;
-	}
-
-	private async syncObjectHierarchyCreate(object: Object3D): Promise<void> {
-		if (this.isSyncingFromApi) {
-			return;
-		}
-
-		if (!this.shouldPersistObject(object)) {
-			return;
-		}
-
-		await this.syncObjectCreate(object);
-
-		for (const child of object.children) {
-			await this.syncObjectHierarchyCreate(child);
-		}
-	}
-
-	private async syncObjectCreate(object: Object3D): Promise<void> {
-		if (!this.activeSpaceId || this.isSyncingFromApi) {
-			return;
-		}
-
-		if (this.getObjectApiId(object)) {
-			await this.syncObjectUpdate(object);
-			return;
-		}
-
-		const payload = this.buildObjectPayload(object);
-		if (!payload) {
-			return;
-		}
-
-		const response = await this.getApiClient().createObject(
-			this.activeSpaceId,
-			payload,
-		);
-
-		this.setObjectApiId(object, response.id);
-	}
-
-	private async syncObjectUpdate(object: Object3D): Promise<void> {
-		if (!this.activeSpaceId || this.isSyncingFromApi) {
-			return;
-		}
-
-		if (!this.shouldPersistObject(object)) {
-			return;
-		}
-
-		const objectId = this.getObjectApiId(object);
-		if (!objectId) {
-			await this.syncObjectCreate(object);
-			return;
-		}
-
-		const payload = this.buildObjectPayload(object);
-		if (!payload) {
-			return;
-		}
-
-		await this.getApiClient().updateObject(
-			this.activeSpaceId,
-			objectId,
-			payload,
-		);
-	}
-
-	private async syncObjectDelete(object: Object3D): Promise<void> {
-		if (!this.activeSpaceId || this.isSyncingFromApi) {
-			return;
-		}
-
-		const objectId = this.getObjectApiId(object);
-		if (!objectId) {
-			return;
-		}
-
-		await this.getApiClient().deleteObject(this.activeSpaceId, objectId);
-
-		this.clearObjectMapping(object);
-	}
-
-	private clearObjectMapping(object: Object3D): void {
-		this.objectApiIds.delete(object.uuid);
-		delete object.userData.apiId;
-
-		for (const child of object.children) {
-			this.clearObjectMapping(child);
-		}
 	}
 
 	private updateEntityObjects(): void {

--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -58,6 +58,12 @@ import { RendererManager } from "./renderer.js";
 import { createMeshObject } from "./mesh-options.js";
 import { EntityGeneric } from "../objects/entity-generic.js";
 import { DT3DCameraToggle } from "./camera-toggle.js";
+import {
+	SpaceApi,
+	type SpaceResponse,
+	type ObjectInstancePayload,
+	type ObjectInstanceResponse,
+} from "../utils/space-api.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -137,6 +143,26 @@ export class DT3DCard extends LitElement {
 	 * Raycaster for interaction with the scene.
 	 */
 	private raycaster: Raycaster = new Raycaster();
+
+	/**
+	 * Active space ID loaded from the API.
+	 */
+	private activeSpaceId: string | null = null;
+
+	/**
+	 * API client for fetching/saving spaces and objects.
+	 */
+	private apiClient: SpaceApi | null = null;
+
+	/**
+	 * Map of three.js object UUIDs to API object IDs.
+	 */
+	private objectApiIds: Map<string, string> = new Map();
+
+	/**
+	 * Flag to avoid syncing while loading from API.
+	 */
+	private isSyncingFromApi: boolean = false;
 
 	/**
 	 * Normalized pointer position.
@@ -308,6 +334,8 @@ export class DT3DCard extends LitElement {
 		this.attachTransform(object);
 
 		this.tree.updateTreeFromScene(this.space, true);
+
+		void this.syncObjectHierarchyCreate(object);
 	}
 
 	/**
@@ -395,6 +423,8 @@ export class DT3DCard extends LitElement {
 		}
 
 		this.tree.updateTreeFromScene();
+
+		void this.syncObjectUpdate(source);
 	}
 
 	/**
@@ -451,6 +481,8 @@ export class DT3DCard extends LitElement {
 		}
 
 		this.tree.updateTreeFromScene(this.space, true);
+
+		void this.syncObjectDelete(target);
 	}
 
 	/**
@@ -476,6 +508,8 @@ export class DT3DCard extends LitElement {
 
 		this.attachTransform(clone);
 		this.tree.updateTreeFromScene(this.space);
+
+		void this.syncObjectHierarchyCreate(clone);
 	}
 
 	/**
@@ -670,6 +704,7 @@ export class DT3DCard extends LitElement {
 		const port = this.config?.port || 8080;
 		const width = 300;
 		const height = 300;
+		this.apiClient = new SpaceApi(port);
 
 		this.style.cssText = `
 			overflow: hidden;
@@ -745,6 +780,9 @@ export class DT3DCard extends LitElement {
 		this.sceneManager = new SceneManager(this.canvas, height, width);
 		this.sceneManager.transform.addEventListener("objectChange", () => {
 			this.tree.refreshSelectedObject();
+			if (this.transform?.object) {
+				void this.syncObjectUpdate(this.transform.object);
+			}
 		});
 
 		this.scene = this.sceneManager.scene;
@@ -806,6 +844,7 @@ export class DT3DCard extends LitElement {
 			object = createMeshObject(type, material);
 			
 			if (object) {
+				object.userData.meshType = type;
 				this.addToScene(object);
 			} else if (type === "upload") {
 				this.selectFile();
@@ -815,10 +854,8 @@ export class DT3DCard extends LitElement {
 		});
 
 
-		// Set base scene and update three
-		this.sceneManager.createDefaultScene();
 		this.tree.scene = this.space;
-		this.tree.updateTreeFromScene(this.space, true);
+		void this.initializeSpaceFromApi();
 
 		// Listen for selection events from the tree
 		this.tree.addEventListener("object-selected", (e: any) => {
@@ -863,6 +900,7 @@ export class DT3DCard extends LitElement {
 			}
 
 			this.tree.refreshSelectedObject();
+			void this.syncObjectUpdate(updatedObject);
 		});
 
 		this.canvas.addEventListener("dblclick", (event: MouseEvent) => {
@@ -958,33 +996,415 @@ export class DT3DCard extends LitElement {
 	 * @param id - The ID of the entity to add.
 	 */
 	private addEntityToScene(id: string): void {
-		const entity = this.hassInstance.states[id];
-		if (!entity) {
-			console.warn("DT3D: Entity not found:", id);
-			return;
-		}
-
-		const domain = id.split(".")[0];
-		let object: Object3D | null = null;
-
-		if (domain === "sensor") {
-			object = new EntitySensor(id, entity);
-		} else if (domain === "binary_sensor") {
-			object = new EntityBinary(id, entity);
-		} else if (domain === "light") {
-			object = new EntityLight(id, entity);
-		} else if (domain === "switch") {
-			object = new EntitySwitch(id, entity);
-		} else {
-			object = new EntityGeneric(id, entity);
-		}
-
+		const object = this.createEntityObject(id);
 		if (!object) {
 			return;
 		}
 
+		object.userData.entityId = id;
 		object.position.set(Math.random() * 2 - 1, 0, Math.random() * 2 - 1);
 		this.addToScene(object, id);
+	}
+
+	private createEntityObject(id: string): Object3D | null {
+		const entity = this.hassInstance?.states?.[id];
+		if (!entity) {
+			console.warn("DT3D: Entity not found:", id);
+			return null;
+		}
+
+		const domain = id.split(".")[0];
+
+		if (domain === "sensor") {
+			return new EntitySensor(id, entity);
+		}
+
+		if (domain === "binary_sensor") {
+			return new EntityBinary(id, entity);
+		}
+
+		if (domain === "light") {
+			return new EntityLight(id, entity);
+		}
+
+		if (domain === "switch") {
+			return new EntitySwitch(id, entity);
+		}
+
+		return new EntityGeneric(id, entity);
+	}
+
+	private getApiClient(): SpaceApi {
+		if (!this.apiClient) {
+			throw new Error("DT3D: API client not initialized");
+		}
+		return this.apiClient;
+	}
+
+	private clearSpace(): void {
+		if (!this.space) {
+			return;
+		}
+
+		this.space.clear();
+		this.objectApiIds.clear();
+	}
+
+	private async initializeSpaceFromApi(): Promise<void> {
+		this.isSyncingFromApi = true;
+
+		try {
+			const apiClient = this.getApiClient();
+			const spaces = await apiClient.listSpaces();
+			let space = spaces[0];
+
+			if (!space) {
+				space = await apiClient.createSpace(
+					"Default Space",
+					"Auto-created space",
+				);
+			}
+
+			this.activeSpaceId = space.id;
+
+			const instances = await apiClient.listObjects(space.id);
+
+			if (instances.length === 0) {
+				this.clearSpace();
+				this.sceneManager.createDefaultScene();
+				this.tree.updateTreeFromScene(this.space, true);
+				this.isSyncingFromApi = false;
+				await this.syncAllObjectsToApi();
+				return;
+			}
+
+			this.loadObjectsFromApi(instances);
+			this.tree.updateTreeFromScene(this.space, true);
+		} catch (error) {
+			console.error("DT3D: Failed to load spaces from API", error);
+			this.clearSpace();
+			this.sceneManager.createDefaultScene();
+			this.tree.updateTreeFromScene(this.space, true);
+		} finally {
+			this.isSyncingFromApi = false;
+		}
+	}
+
+	private loadObjectsFromApi(instances: ObjectInstanceResponse[]): void {
+		this.clearSpace();
+
+		const objectsById = new Map<string, Object3D>();
+
+		for (const instance of instances) {
+			const object = this.createObjectFromInstance(instance);
+			if (!object) {
+				continue;
+			}
+
+			object.userData.apiId = instance.id;
+			this.objectApiIds.set(object.uuid, instance.id);
+			objectsById.set(instance.id, object);
+		}
+
+		for (const instance of instances) {
+			const object = objectsById.get(instance.id);
+			if (!object) {
+				continue;
+			}
+
+			const parentId = instance.parent_id;
+			const parent = parentId ? objectsById.get(parentId) : null;
+			if (parent) {
+				parent.add(object);
+			} else {
+				this.space.add(object);
+			}
+
+			if (object instanceof DTObject) {
+				object.init();
+			}
+		}
+	}
+
+	private createObjectFromInstance(instance: ObjectInstanceResponse): Object3D | null {
+		const data = instance.data ?? {};
+		let object: Object3D | null = null;
+
+		if (instance.type === "mesh") {
+			const meshType = data.meshType as string | undefined;
+			if (!meshType) {
+				return null;
+			}
+
+			const color = typeof data.color === "string" ? parseInt(data.color, 16) : 0xffffff;
+			const material = new MeshStandardMaterial({ color });
+			object = createMeshObject(meshType, material);
+			if (object) {
+				object.userData.meshType = meshType;
+			}
+		} else if (instance.type === "entity") {
+			const entityId = data.entityId as string | undefined;
+			if (!entityId) {
+				return null;
+			}
+
+			object = this.createEntityObject(entityId);
+			if (object) {
+				object.userData.entityId = entityId;
+			}
+		} else if (instance.type === "group") {
+			object = new Group();
+		}
+
+		if (!object) {
+			return null;
+		}
+
+		object.name = instance.name || object.name;
+		this.applyObjectTransform(object, data);
+
+		if (object instanceof DTObject && typeof data.locked === "boolean") {
+			object.locked = data.locked;
+		}
+
+		return object;
+	}
+
+	private applyObjectTransform(object: Object3D, data: Record<string, any>): void {
+		const position = data.position as { x?: number; y?: number; z?: number } | undefined;
+		if (position) {
+			object.position.set(position.x ?? 0, position.y ?? 0, position.z ?? 0);
+		}
+
+		const rotation = data.rotation as { x?: number; y?: number; z?: number } | undefined;
+		if (rotation) {
+			object.rotation.set(rotation.x ?? 0, rotation.y ?? 0, rotation.z ?? 0);
+		}
+
+		const scale = data.scale as { x?: number; y?: number; z?: number } | undefined;
+		if (scale) {
+			object.scale.set(scale.x ?? 1, scale.y ?? 1, scale.z ?? 1);
+		}
+	}
+
+	private resolveMeshType(object: Object3D): string | null {
+		const meshType = object.userData.meshType as string | undefined;
+		if (meshType) {
+			return meshType;
+		}
+
+		if (object instanceof Mesh) {
+			switch (object.geometry?.type) {
+				case "BoxGeometry":
+					return "cube";
+				case "SphereGeometry":
+					return "sphere";
+				case "PlaneGeometry":
+					return "plane";
+				case "CapsuleGeometry":
+					return "capsule";
+				case "CircleGeometry":
+					return "circle";
+				case "ConeGeometry":
+					return "cone";
+				case "CylinderGeometry":
+					return "cylinder";
+				case "DodecahedronGeometry":
+					return "dodecahedron";
+				case "IcosahedronGeometry":
+					return "icosahedron";
+				case "OctahedronGeometry":
+					return "octahedron";
+				case "RingGeometry":
+					return "ring";
+				case "TetrahedronGeometry":
+					return "tetrahedron";
+				case "TorusGeometry":
+					return "torus";
+				case "TorusKnotGeometry":
+					return "torusKnot";
+				default:
+					return null;
+			}
+		}
+
+		return null;
+	}
+
+	private async syncAllObjectsToApi(): Promise<void> {
+		if (!this.space) {
+			return;
+		}
+
+		for (const child of this.space.children) {
+			await this.syncObjectHierarchyCreate(child);
+		}
+	}
+
+	private shouldPersistObject(object: Object3D): boolean {
+		if (!this.space || object === this.space) {
+			return false;
+		}
+
+		if ((object as any).internal === true) {
+			return false;
+		}
+
+		return object.parent === this.space || this.isDescendant(object, this.space);
+	}
+
+	private buildObjectPayload(object: Object3D): ObjectInstancePayload | null {
+		if (!this.activeSpaceId || !this.shouldPersistObject(object)) {
+			return null;
+		}
+
+		let type = "group";
+		const data: Record<string, any> = {
+			position: {
+				x: object.position.x,
+				y: object.position.y,
+				z: object.position.z,
+			},
+			rotation: {
+				x: object.rotation.x,
+				y: object.rotation.y,
+				z: object.rotation.z,
+			},
+			scale: {
+				x: object.scale.x,
+				y: object.scale.y,
+				z: object.scale.z,
+			},
+		};
+
+		if (object instanceof EntityObject) {
+			type = "entity";
+			data.entityId = object.entityId;
+		} else {
+			const meshType = this.resolveMeshType(object);
+			if (meshType) {
+				type = "mesh";
+				data.meshType = meshType;
+
+				const material = (object as any).material;
+				if (material?.color?.getHexString) {
+					data.color = material.color.getHexString();
+				}
+			}
+		}
+
+		if (object instanceof DTObject) {
+			data.locked = object.locked;
+		}
+
+		const parent = object.parent && object.parent !== this.space ? object.parent : null;
+		const parentId = parent ? this.getObjectApiId(parent) : null;
+
+		return {
+			name: object.name || "Object",
+			type,
+			data,
+			parent_id: parentId ?? null,
+		};
+	}
+
+	private getObjectApiId(object: Object3D): string | undefined {
+		return this.objectApiIds.get(object.uuid) ?? object.userData.apiId;
+	}
+
+	private setObjectApiId(object: Object3D, id: string): void {
+		this.objectApiIds.set(object.uuid, id);
+		object.userData.apiId = id;
+	}
+
+	private async syncObjectHierarchyCreate(object: Object3D): Promise<void> {
+		if (this.isSyncingFromApi) {
+			return;
+		}
+
+		if (!this.shouldPersistObject(object)) {
+			return;
+		}
+
+		await this.syncObjectCreate(object);
+
+		for (const child of object.children) {
+			await this.syncObjectHierarchyCreate(child);
+		}
+	}
+
+	private async syncObjectCreate(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		if (this.getObjectApiId(object)) {
+			await this.syncObjectUpdate(object);
+			return;
+		}
+
+		const payload = this.buildObjectPayload(object);
+		if (!payload) {
+			return;
+		}
+
+		const response = await this.getApiClient().createObject(
+			this.activeSpaceId,
+			payload,
+		);
+
+		this.setObjectApiId(object, response.id);
+	}
+
+	private async syncObjectUpdate(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		if (!this.shouldPersistObject(object)) {
+			return;
+		}
+
+		const objectId = this.getObjectApiId(object);
+		if (!objectId) {
+			await this.syncObjectCreate(object);
+			return;
+		}
+
+		const payload = this.buildObjectPayload(object);
+		if (!payload) {
+			return;
+		}
+
+		await this.getApiClient().updateObject(
+			this.activeSpaceId,
+			objectId,
+			payload,
+		);
+	}
+
+	private async syncObjectDelete(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		const objectId = this.getObjectApiId(object);
+		if (!objectId) {
+			return;
+		}
+
+		await this.getApiClient().deleteObject(this.activeSpaceId, objectId);
+
+		this.clearObjectMapping(object);
+	}
+
+	private clearObjectMapping(object: Object3D): void {
+		this.objectApiIds.delete(object.uuid);
+		delete object.userData.apiId;
+
+		for (const child of object.children) {
+			this.clearObjectMapping(child);
+		}
 	}
 
 	private updateEntityObjects(): void {

--- a/frontend/src/components/scene.ts
+++ b/frontend/src/components/scene.ts
@@ -110,6 +110,8 @@ export class SceneManager {
 		const geometry = new BoxGeometry();
 		const material = new MeshStandardMaterial({ color: 0xffff00 });
 		const cube = new Mesh(geometry, material);
+		cube.name = "Cube";
+		cube.userData.meshType = "cube";
 		this.transform.attach(cube);
 		this.space.add(cube);
 
@@ -119,6 +121,8 @@ export class SceneManager {
 		const plane = new Mesh(planeGeometry, planeMaterial);
 		plane.rotation.x = -Math.PI / 2; // Rotate to make it horizontal
 		plane.position.y = -1; // Position it below the cube
+		plane.name = "Plane";
+		plane.userData.meshType = "plane";
 		this.space.add(plane);
 
 	}

--- a/frontend/src/utils/space-api.ts
+++ b/frontend/src/utils/space-api.ts
@@ -1,0 +1,122 @@
+export type SpaceResponse = {
+	id: string;
+	name: string;
+	description: string;
+	created_at: number;
+	updated_at: number;
+	object_instances: ObjectInstanceResponse[];
+};
+
+export type ObjectInstanceResponse = {
+	id: string;
+	space_id: string;
+	parent_id: string | null;
+	name: string;
+	type: string;
+	data: Record<string, any> | null;
+	created_at: number;
+	updated_at: number;
+};
+
+export type ObjectInstancePayload = {
+	name: string;
+	type: string;
+	data: Record<string, any>;
+	parent_id: string | null;
+};
+
+/**
+ * SpaceApi wraps HTTP calls to the backend space endpoints.
+ * It centralizes request configuration and response typing.
+ */
+export class SpaceApi {
+	private baseUrl: string;
+
+	constructor(port: number) {
+		this.baseUrl = `http://localhost:${port}/api`;
+	}
+
+	/**
+	 * Get all spaces from the backend.
+	 */
+	public listSpaces(): Promise<SpaceResponse[]> {
+		return this.fetchJson<SpaceResponse[]>("/spaces");
+	}
+
+	/**
+	 * Create a new space with the provided name/description.
+	 */
+	public createSpace(name: string, description: string): Promise<SpaceResponse> {
+		return this.fetchJson<SpaceResponse>("/spaces", {
+			method: "POST",
+			body: JSON.stringify({ name, description }),
+		});
+	}
+
+	/**
+	 * Fetch all object instances for a space.
+	 */
+	public listObjects(spaceId: string): Promise<ObjectInstanceResponse[]> {
+		return this.fetchJson<ObjectInstanceResponse[]>(`/spaces/${spaceId}/objects`);
+	}
+
+	/**
+	 * Create a new object instance.
+	 */
+	public createObject(
+		spaceId: string,
+		payload: ObjectInstancePayload,
+	): Promise<ObjectInstanceResponse> {
+		return this.fetchJson<ObjectInstanceResponse>(`/spaces/${spaceId}/objects`, {
+			method: "POST",
+			body: JSON.stringify(payload),
+		});
+	}
+
+	/**
+	 * Update an existing object instance.
+	 */
+	public updateObject(
+		spaceId: string,
+		objectId: string,
+		payload: ObjectInstancePayload,
+	): Promise<ObjectInstanceResponse> {
+		return this.fetchJson<ObjectInstanceResponse>(
+			`/spaces/${spaceId}/objects/${objectId}`,
+			{
+				method: "PUT",
+				body: JSON.stringify(payload),
+			},
+		);
+	}
+
+	/**
+	 * Delete an object instance from the backend.
+	 */
+	public deleteObject(spaceId: string, objectId: string): Promise<void> {
+		return this.fetchJson<void>(`/spaces/${spaceId}/objects/${objectId}`, {
+			method: "DELETE",
+		});
+	}
+
+	private async fetchJson<T>(path: string, options?: RequestInit): Promise<T> {
+		const response = await fetch(`${this.baseUrl}${path}`, {
+			headers: {
+				"Content-Type": "application/json",
+				...(options?.headers ?? {}),
+			},
+			...options,
+		});
+
+		if (!response.ok) {
+			const message = await response.text();
+			throw new Error(message || `Request failed: ${response.status}`);
+		}
+
+		if (response.status === 204) {
+			return null as T;
+		}
+
+		return response.json() as Promise<T>;
+	}
+}

--- a/frontend/src/utils/space-sync.ts
+++ b/frontend/src/utils/space-sync.ts
@@ -1,0 +1,393 @@
+import { Group, MeshStandardMaterial, Object3D } from "three";
+import type { Mesh } from "three";
+import type { SceneManager } from "../components/scene.js";
+import type { DT3DTree } from "../components/object-tree/object-tree.js";
+import { createMeshObject } from "../components/mesh-options.js";
+import { DTObject } from "../objects/dt-object.js";
+import { EntityObject } from "../objects/entity-object.js";
+import {
+	SpaceApi,
+	type ObjectInstancePayload,
+	type ObjectInstanceResponse,
+} from "./space-api.js";
+
+type SpaceSyncDependencies = {
+	apiClient: SpaceApi;
+	sceneManager: SceneManager;
+	space: Group;
+	tree: DT3DTree;
+	resolveMeshType: (object: Object3D) => string | null;
+	createEntityObject: (entityId: string) => Object3D | null;
+};
+
+/**
+ * SpaceSync handles loading spaces and syncing object changes with the API.
+ */
+export class SpaceSync {
+	private apiClient: SpaceApi;
+	private sceneManager: SceneManager;
+	private space: Group;
+	private tree: DT3DTree;
+	private resolveMeshType: (object: Object3D) => string | null;
+	private createEntityObject: (entityId: string) => Object3D | null;
+	private objectApiIds: Map<string, string> = new Map();
+	private isSyncingFromApi = false;
+
+	public activeSpaceId: string | null = null;
+
+	constructor({
+		apiClient,
+		sceneManager,
+		space,
+		tree,
+		resolveMeshType,
+		createEntityObject,
+	}: SpaceSyncDependencies) {
+		this.apiClient = apiClient;
+		this.sceneManager = sceneManager;
+		this.space = space;
+		this.tree = tree;
+		this.resolveMeshType = resolveMeshType;
+		this.createEntityObject = createEntityObject;
+	}
+
+	/**
+	 * Clear all objects from the active space and reset API mappings.
+	 */
+	public clearSpace(): void {
+		this.space.clear();
+		this.objectApiIds.clear();
+	}
+
+	/**
+	 * Fetch spaces from the API and load the first available space.
+	 * When no spaces exist, a default space is created automatically.
+	 */
+	public async initializeSpaceFromApi(): Promise<void> {
+		this.isSyncingFromApi = true;
+
+		try {
+			const spaces = await this.apiClient.listSpaces();
+			let space = spaces[0];
+
+			if (!space) {
+				space = await this.apiClient.createSpace(
+					"Default Space",
+					"Auto-created space",
+				);
+			}
+
+			this.activeSpaceId = space.id;
+
+			const instances = await this.apiClient.listObjects(space.id);
+
+			if (instances.length === 0) {
+				this.clearSpace();
+				this.sceneManager.createDefaultScene();
+				this.tree.updateTreeFromScene(this.space, true);
+				this.isSyncingFromApi = false;
+				await this.syncAllObjectsToApi();
+				return;
+			}
+
+			this.loadObjectsFromApi(instances);
+			this.tree.updateTreeFromScene(this.space, true);
+		} catch (error) {
+			console.error("DT3D: Failed to load spaces from API", error);
+			this.clearSpace();
+			this.sceneManager.createDefaultScene();
+			this.tree.updateTreeFromScene(this.space, true);
+		} finally {
+			this.isSyncingFromApi = false;
+		}
+	}
+
+	/**
+	 * Load object instances into the space and reconstruct hierarchy.
+	 */
+	public loadObjectsFromApi(instances: ObjectInstanceResponse[]): void {
+		this.clearSpace();
+
+		const objectsById = new Map<string, Object3D>();
+
+		for (const instance of instances) {
+			const object = this.createObjectFromInstance(instance);
+			if (!object) {
+				continue;
+			}
+
+			object.userData.apiId = instance.id;
+			this.objectApiIds.set(object.uuid, instance.id);
+			objectsById.set(instance.id, object);
+		}
+
+		for (const instance of instances) {
+			const object = objectsById.get(instance.id);
+			if (!object) {
+				continue;
+			}
+
+			const parentId = instance.parent_id;
+			const parent = parentId ? objectsById.get(parentId) : null;
+			if (parent) {
+				parent.add(object);
+			} else {
+				this.space.add(object);
+			}
+
+			if (object instanceof DTObject) {
+				object.init();
+			}
+		}
+	}
+
+	/**
+	 * Convert an API object instance into a three.js object.
+	 */
+	public createObjectFromInstance(
+		instance: ObjectInstanceResponse,
+	): Object3D | null {
+		const data = instance.data ?? {};
+		let object: Object3D | null = null;
+
+		if (instance.type === "mesh") {
+			const meshType = data.meshType as string | undefined;
+			if (!meshType) {
+				return null;
+			}
+
+			const color = typeof data.color === "string" ? parseInt(data.color, 16) : 0xffffff;
+			const material = new MeshStandardMaterial({ color });
+			object = createMeshObject(meshType, material);
+			if (object) {
+				object.userData.meshType = meshType;
+			}
+		} else if (instance.type === "entity") {
+			const entityId = data.entityId as string | undefined;
+			if (!entityId) {
+				return null;
+			}
+
+			object = this.createEntityObject(entityId);
+			if (object) {
+				object.userData.entityId = entityId;
+			}
+		} else if (instance.type === "group") {
+			object = new Group();
+		}
+
+		if (!object) {
+			return null;
+		}
+
+		object.name = instance.name || object.name;
+		this.applyObjectTransform(object, data);
+
+		if (object instanceof DTObject && typeof data.locked === "boolean") {
+			object.locked = data.locked;
+		}
+
+		return object;
+	}
+
+	/**
+	 * Build an API payload from a three.js object.
+	 */
+	public buildObjectPayload(object: Object3D): ObjectInstancePayload | null {
+		if (!this.activeSpaceId || !this.shouldPersistObject(object)) {
+			return null;
+		}
+
+		let type = "group";
+		const data: Record<string, any> = {
+			position: {
+				x: object.position.x,
+				y: object.position.y,
+				z: object.position.z,
+			},
+			rotation: {
+				x: object.rotation.x,
+				y: object.rotation.y,
+				z: object.rotation.z,
+			},
+			scale: {
+				x: object.scale.x,
+				y: object.scale.y,
+				z: object.scale.z,
+			},
+		};
+
+		if (object instanceof EntityObject) {
+			type = "entity";
+			data.entityId = object.entityId;
+		} else {
+			const meshType = this.resolveMeshType(object);
+			if (meshType) {
+				type = "mesh";
+				data.meshType = meshType;
+
+				const material = (object as Mesh).material as any;
+				if (material?.color?.getHexString) {
+					data.color = material.color.getHexString();
+				}
+			}
+		}
+
+		if (object instanceof DTObject) {
+			data.locked = object.locked;
+		}
+
+		const parent = object.parent && object.parent !== this.space ? object.parent : null;
+		const parentId = parent ? this.getObjectApiId(parent) : null;
+
+		return {
+			name: object.name || "Object",
+			type,
+			data,
+			parent_id: parentId ?? null,
+		};
+	}
+
+	/**
+	 * Sync a full object subtree to the API (creates/updates as needed).
+	 */
+	public async syncObjectHierarchyCreate(object: Object3D): Promise<void> {
+		if (this.isSyncingFromApi || !this.shouldPersistObject(object)) {
+			return;
+		}
+
+		await this.syncObjectCreate(object);
+
+		for (const child of object.children) {
+			await this.syncObjectHierarchyCreate(child);
+		}
+	}
+
+	/**
+	 * Create a single object in the API or update if already present.
+	 */
+	public async syncObjectCreate(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		if (this.getObjectApiId(object)) {
+			await this.syncObjectUpdate(object);
+			return;
+		}
+
+		const payload = this.buildObjectPayload(object);
+		if (!payload) {
+			return;
+		}
+
+		const response = await this.apiClient.createObject(this.activeSpaceId, payload);
+		this.setObjectApiId(object, response.id);
+	}
+
+	/**
+	 * Update a single object in the API.
+	 */
+	public async syncObjectUpdate(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		if (!this.shouldPersistObject(object)) {
+			return;
+		}
+
+		const objectId = this.getObjectApiId(object);
+		if (!objectId) {
+			await this.syncObjectCreate(object);
+			return;
+		}
+
+		const payload = this.buildObjectPayload(object);
+		if (!payload) {
+			return;
+		}
+
+		await this.apiClient.updateObject(this.activeSpaceId, objectId, payload);
+	}
+
+	/**
+	 * Delete an object in the API and clear all stored mappings.
+	 */
+	public async syncObjectDelete(object: Object3D): Promise<void> {
+		if (!this.activeSpaceId || this.isSyncingFromApi) {
+			return;
+		}
+
+		const objectId = this.getObjectApiId(object);
+		if (!objectId) {
+			return;
+		}
+
+		await this.apiClient.deleteObject(this.activeSpaceId, objectId);
+		this.clearObjectMapping(object);
+	}
+
+	public syncAllObjectsToApi(): Promise<void[]> {
+		return Promise.all(this.space.children.map((child) => this.syncObjectHierarchyCreate(child)));
+	}
+
+	private applyObjectTransform(object: Object3D, data: Record<string, any>): void {
+		const position = data.position as { x?: number; y?: number; z?: number } | undefined;
+		if (position) {
+			object.position.set(position.x ?? 0, position.y ?? 0, position.z ?? 0);
+		}
+
+		const rotation = data.rotation as { x?: number; y?: number; z?: number } | undefined;
+		if (rotation) {
+			object.rotation.set(rotation.x ?? 0, rotation.y ?? 0, rotation.z ?? 0);
+		}
+
+		const scale = data.scale as { x?: number; y?: number; z?: number } | undefined;
+		if (scale) {
+			object.scale.set(scale.x ?? 1, scale.y ?? 1, scale.z ?? 1);
+		}
+	}
+
+	private shouldPersistObject(object: Object3D): boolean {
+		if (object === this.space) {
+			return false;
+		}
+
+		if ((object as any).internal === true) {
+			return false;
+		}
+
+		return object.parent === this.space || this.isDescendant(object, this.space);
+	}
+
+	private isDescendant(object: Object3D, ancestor: Object3D): boolean {
+		let current = object.parent;
+		while (current) {
+			if (current === ancestor) {
+				return true;
+			}
+			current = current.parent;
+		}
+
+		return false;
+	}
+
+	private getObjectApiId(object: Object3D): string | undefined {
+		return this.objectApiIds.get(object.uuid) ?? object.userData.apiId;
+	}
+
+	private setObjectApiId(object: Object3D, id: string): void {
+		this.objectApiIds.set(object.uuid, id);
+		object.userData.apiId = id;
+	}
+
+	private clearObjectMapping(object: Object3D): void {
+		this.objectApiIds.delete(object.uuid);
+		delete object.userData.apiId;
+
+		for (const child of object.children) {
+			this.clearObjectMapping(child);
+		}
+	}
+}


### PR DESCRIPTION
### Motivation
- Separate HTTP/space sync responsibilities from the UI so backend calls are centralized and easier to maintain. 
- Provide typed API surface and documentation for space/object endpoints to reduce duplication and clarify intent. 
- Keep the card focused on scene logic and delegate network interactions to a single client.

### Description
- Added a documented `SpaceApi` client in `frontend/src/utils/space-api.ts` that exposes typed methods `listSpaces`, `createSpace`, `listObjects`, `createObject`, `updateObject`, and `deleteObject`, plus a shared `fetchJson` helper; included types `SpaceResponse`, `ObjectInstanceResponse`, and `ObjectInstancePayload`.
- Updated `frontend/src/components/card.ts` to initialize and use `SpaceApi` (`this.apiClient`) and removed the in-file `fetchJson`/base URL logic, replacing it with `getApiClient()` calls.
- Moved and refactored space/object sync & hydration logic into `card.ts` to use the new client, including `initializeSpaceFromApi`, `loadObjectsFromApi`, `createObjectFromInstance`, `applyObjectTransform`, `resolveMeshType`, object payload builders (`buildObjectPayload`), mapping management helpers (`getObjectApiId`, `setObjectApiId`, `clearObjectMapping`) and sync flows (`syncAllObjectsToApi`, `syncObjectHierarchyCreate`, `syncObjectCreate`, `syncObjectUpdate`, `syncObjectDelete`, `shouldPersistObject`).
- Minor scene adjustments in `frontend/src/components/scene.ts` to tag default primitives (`userData.meshType`) so primitives persist/serialize cleanly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d220251248332aa6e123f11ffc4f5)