### PR TITLE
Add stored file upload/delete API with disk storage and static serving

### DIFF
--- a/addon/backend/go.mod
+++ b/addon/backend/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/gin-gonic/gin v1.11.0
+	github.com/google/uuid v1.6.0
 	gorm.io/datatypes v1.2.7
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.1
@@ -24,7 +25,6 @@ require (
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.19.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/addon/backend/handlers/file.go
+++ b/addon/backend/handlers/file.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"dt3d-ha/backend/service"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+type FileHandler struct {
+	files *service.StoredFileService
+}
+
+func NewFileHandler(fileService *service.StoredFileService) *FileHandler {
+	return &FileHandler{files: fileService}
+}
+
+func (h *FileHandler) Register(router *gin.Engine) {
+	files := router.Group("/api/files")
+	{
+		files.POST("", h.uploadFile)
+		files.DELETE(":fileID", h.deleteFile)
+	}
+}
+
+func (h *FileHandler) uploadFile(c *gin.Context) {
+	fileHeader, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file is required"})
+		return
+	}
+
+	file, err := fileHeader.Open()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read upload"})
+		return
+	}
+	defer file.Close()
+
+	record, err := h.files.CreateFile(service.CreateStoredFileInput{
+		Filename: fileHeader.Filename,
+		Reader:   file,
+	})
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, toStoredFileResponse(*record))
+}
+
+func (h *FileHandler) deleteFile(c *gin.Context) {
+	fileID := c.Param("fileID")
+	if err := h.files.DeleteFile(fileID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "file not found"})
+			return
+		}
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/addon/backend/handlers/router.go
+++ b/addon/backend/handlers/router.go
@@ -2,9 +2,10 @@ package handlers
 
 import "github.com/gin-gonic/gin"
 
-func RegisterRoutes(router *gin.Engine, spaceHandler *SpaceHandler) {
+func RegisterRoutes(router *gin.Engine, spaceHandler *SpaceHandler, fileHandler *FileHandler) {
 	hello := NewHelloHandler()
 	hello.Register(router)
 
 	spaceHandler.Register(router)
+	fileHandler.Register(router)
 }

--- a/addon/backend/handlers/types.go
+++ b/addon/backend/handlers/types.go
@@ -58,6 +58,14 @@ type objectTreeNodeResponse struct {
 	Children []objectTreeNodeResponse `json:"children,omitempty"`
 }
 
+type storedFileResponse struct {
+	ID        string `json:"id"`
+	Filename  string `json:"filename"`
+	Format    string `json:"format"`
+	CreatedAt int64  `json:"created_at"`
+	UpdatedAt int64  `json:"updated_at"`
+}
+
 func toObjectInstanceResponse(instance models.ObjectInstance) objectInstanceResponse {
 	data := json.RawMessage(instance.Data)
 	if len(data) == 0 {
@@ -107,6 +115,16 @@ func toObjectTreeNodeResponse(node *service.ObjectTreeNode) objectTreeNodeRespon
 		Type:     node.Type,
 		Data:     data,
 		Children: children,
+	}
+}
+
+func toStoredFileResponse(file models.StoredFile) storedFileResponse {
+	return storedFileResponse{
+		ID:        file.ID,
+		Filename:  file.Filename,
+		Format:    file.Format,
+		CreatedAt: file.CreatedAt,
+		UpdatedAt: file.UpdatedAt,
 	}
 }
 

--- a/addon/backend/main.go
+++ b/addon/backend/main.go
@@ -48,14 +48,21 @@ func main() {
 	if err := db.AutoMigrate(&models.Space{}, &models.ObjectInstance{}); err != nil {
 		log.Fatalf("failed to migrate database: %v", err)
 	}
+	if err := db.AutoMigrate(&models.StoredFile{}); err != nil {
+		log.Fatalf("failed to migrate database: %v", err)
+	}
 
 	spaceRepo := repository.NewSpaceRepository(db)
 	objectRepo := repository.NewObjectInstanceRepository(db)
 	spaceService := service.NewSpaceService(spaceRepo, objectRepo)
+	fileRepo := repository.NewStoredFileRepository(db)
+	fileService := service.NewStoredFileService(fileRepo, "data")
 
 	router := gin.Default()
+	router.Static("/data", "./data")
 	spaceHandler := handlers.NewSpaceHandler(spaceService)
-	handlers.RegisterRoutes(router, spaceHandler)
+	fileHandler := handlers.NewFileHandler(fileService)
+	handlers.RegisterRoutes(router, spaceHandler, fileHandler)
 
 	log.Printf("Listening on :%d", port)
 	if err := router.Run(fmt.Sprintf(":%d", port)); err != nil {

--- a/addon/backend/models/file.go
+++ b/addon/backend/models/file.go
@@ -1,0 +1,9 @@
+package models
+
+type StoredFile struct {
+	Base
+
+	Filename    string `gorm:"size:255" json:"filename"`
+	Format      string `gorm:"size:32" json:"format"`
+	StoragePath string `gorm:"size:1024" json:"storage_path"`
+}

--- a/addon/backend/repository/stored_file.go
+++ b/addon/backend/repository/stored_file.go
@@ -1,0 +1,31 @@
+package repository
+
+import (
+	"dt3d-ha/backend/models"
+
+	"gorm.io/gorm"
+)
+
+type StoredFileRepository struct {
+	db *gorm.DB
+}
+
+func NewStoredFileRepository(db *gorm.DB) *StoredFileRepository {
+	return &StoredFileRepository{db: db}
+}
+
+func (r *StoredFileRepository) Create(file *models.StoredFile) error {
+	return r.db.Create(file).Error
+}
+
+func (r *StoredFileRepository) FindByID(id string) (*models.StoredFile, error) {
+	var file models.StoredFile
+	if err := r.db.First(&file, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &file, nil
+}
+
+func (r *StoredFileRepository) Delete(id string) error {
+	return r.db.Delete(&models.StoredFile{}, "id = ?", id).Error
+}

--- a/addon/backend/service/stored_file.go
+++ b/addon/backend/service/stored_file.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"dt3d-ha/backend/models"
+	"dt3d-ha/backend/repository"
+
+	"github.com/google/uuid"
+)
+
+type StoredFileService struct {
+	files    *repository.StoredFileRepository
+	dataPath string
+}
+
+func NewStoredFileService(fileRepo *repository.StoredFileRepository, dataPath string) *StoredFileService {
+	return &StoredFileService{files: fileRepo, dataPath: dataPath}
+}
+
+type CreateStoredFileInput struct {
+	Filename string
+	Reader   io.Reader
+}
+
+func (s *StoredFileService) CreateFile(input CreateStoredFileInput) (*models.StoredFile, error) {
+	input.Filename = strings.TrimSpace(input.Filename)
+	if input.Filename == "" {
+		return nil, errors.New("filename is required")
+	}
+	if input.Reader == nil {
+		return nil, errors.New("file content is required")
+	}
+
+	if err := os.MkdirAll(s.dataPath, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to ensure data directory: %w", err)
+	}
+
+	ext := strings.TrimPrefix(filepath.Ext(input.Filename), ".")
+	if ext == "" {
+		ext = "bin"
+	}
+
+	fileID := uuid.NewString()
+	storageName := fmt.Sprintf("%s.%s", fileID, ext)
+	storagePath := filepath.Join(s.dataPath, storageName)
+
+	out, err := os.Create(storagePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, input.Reader); err != nil {
+		return nil, fmt.Errorf("failed to write file: %w", err)
+	}
+
+	record := &models.StoredFile{
+		Filename:    input.Filename,
+		Format:      ext,
+		StoragePath: storagePath,
+	}
+
+	if err := s.files.Create(record); err != nil {
+		_ = os.Remove(storagePath)
+		return nil, fmt.Errorf("failed to persist file metadata: %w", err)
+	}
+
+	return record, nil
+}
+
+func (s *StoredFileService) DeleteFile(id string) error {
+	record, err := s.files.FindByID(id)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(record.StoragePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to delete stored file: %w", err)
+	}
+
+	if err := s.files.Delete(id); err != nil {
+		return fmt.Errorf("failed to delete file metadata: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
### Motivation
- Provide backend file storage that persists uploaded files on disk as `data/uuid.format` and records metadata (filename, format, timestamps) in the database.
- Expose simple upload and deletion endpoints and make stored files retrievable via a served `data` path.

### Description
- Added `models.StoredFile` to store `Filename`, `Format`, and `StoragePath` with timestamps via the existing `Base` model.
- Implemented `repository.StoredFileRepository` and `service.StoredFileService` which create files under the `data` directory (named `uuid.ext`) and persist metadata; deletion removes both file and DB record.
- Added `FileHandler` exposing `POST /api/files` for uploads and `DELETE /api/files/:fileID` for removals and wired the handler into `RegisterRoutes`.
- Enabled static serving with `router.Static("/data", "./data")` and added `db.AutoMigrate(&models.StoredFile{})` in `main.go`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f3e5ac09c8332b13385dffc462144)