### PR TITLE
Extract measurement handling into MeasurementManager

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -24,7 +24,6 @@ import {
 	SphereGeometry,
 	Vector2,
 	Group,
-	Vector3,
 	TetrahedronGeometry,
 	TorusGeometry,
 	TorusKnotGeometry,
@@ -48,9 +47,6 @@ import { EntityObject } from "../objects/entity-object.js";
 import { DT3DAddEntityModal } from "./add-entity-modal.js";
 import { DTObject } from "../objects/dt-object.js";
 import en from "../locale/en.json";
-import { Marker } from "../objects/measurement/marker.js";
-import { AngleMeasurement } from "../objects/measurement/angle.js";
-import { DistanceMeasurement } from "../objects/measurement/distance.js";
 import { ConnectionStatus } from "./connection-status/connection-status.js";
 import { SceneManager } from "./scene.js";
 import type { CameraMode } from "./scene.js";
@@ -60,6 +56,7 @@ import { EntityGeneric } from "../objects/entity-generic.js";
 import { DT3DCameraToggle } from "./camera-toggle.js";
 import { SpaceApi } from "../utils/space-api.js";
 import { SpaceSync } from "../utils/space-sync.js";
+import { MeasurementManager } from "./measurement-manager.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -121,19 +118,9 @@ export class DT3DCard extends LitElement {
 	public tree: DT3DTree;
 
 	/**
-	 * Tracks which measurement tool is currently active.
+	 * Handles measurement interactions and helper rendering.
 	 */
-	private measurementMode: "none" | "distance" | "angle" = "none";
-
-	/**
-	 * Points selected for the current measurement operation.
-	 */
-	private measurementPoints: Vector3[] = [];
-
-	/**
-	 * Helper group that renders measurement visuals (markers, lines, labels).
-	 */
-	private measurementHelpers: Group = null;
+	private measurementManager: MeasurementManager | null = null;
 
 	/**
 	 * Raycaster for interaction with the scene.
@@ -410,60 +397,12 @@ export class DT3DCard extends LitElement {
 	}
 
 	/**
-	 * Change the measurement mode.
-	 * 
-	 * @param mode - Measurement mode to be used.
-	 */
-	private setMeasurementMode(mode: "distance" | "angle" | "none"): void {
-		this.measurementMode = mode;
-		this.clearMeasurements();
-	}
-
-	/**
-	 * Clear the measurements.
-	 */
-	private clearMeasurements(): void {
-		this.measurementPoints = [];
-		this.measurementHelpers.clear();
-	}
-
-	/**
-	 * Add a new measurement point.
-	 * 
-	 * @param event - Mouse event.
-	 */
-	private processMeasurementClick(event: MouseEvent): void {
-		if (this.measurementMode === "none" || !this.canvas || !this.camera || !this.space) {
-			return;
-		}
-
-		const rect = this.canvas.getBoundingClientRect();
-		this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-		this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
-		this.raycaster.setFromCamera(this.pointer, this.camera);
-
-		const intersects = this.raycaster.intersectObjects(
-			this.space.children,
-			true,
-		);
-		const point = intersects[0]?.point;
-
-		if (!point) {
-			return;
-		}
-
-		this.addMeasurementPoint(point);
-	}
-
-	/**
 	 * Handle canvas click events.
 	 * 
 	 * @param event - Mouse event
 	 */
 	private handleCanvasClick(event: MouseEvent): void {
-		// If measrement mode is active, process measurement click
-		if (this.measurementMode !== "none") {
-			this.processMeasurementClick(event);
+		if (this.measurementManager?.handleClick(event)) {
 			return;
 		}
 
@@ -555,38 +494,6 @@ export class DT3DCard extends LitElement {
 	}
 
 
-
-	/**
-	 * Add a measurement point based on the current measurement mode.
-	 *
-	 * @param point - Position of the measurement point.
-	 */
-	private addMeasurementPoint(point: Vector3): void {
-		this.measurementPoints.push(point.clone());
-
-		if (
-			this.measurementMode === "distance" &&
-			this.measurementPoints.length === 2
-		) {
-			const points = [...this.measurementPoints];
-			this.measurementHelpers.clear();
-			this.measurementHelpers.add(new DistanceMeasurement(points));
-			this.measurementPoints = [];
-		} else if (
-			this.measurementMode === "angle" &&
-			this.measurementPoints.length === 3
-		) {
-			const points = [...this.measurementPoints];
-			this.measurementHelpers.clear();
-			this.measurementHelpers.add(new AngleMeasurement(points));
-			this.measurementPoints = [];
-		} else {
-			this.measurementHelpers.clear();
-			this.measurementPoints.forEach((point) => {
-				this.measurementHelpers.add(new Marker(point));
-			});
-		}
-	}
 
 	/**
 	 * Method called when the element is added to the DOM.
@@ -687,7 +594,14 @@ export class DT3DCard extends LitElement {
 		this.controls = this.sceneManager.controls;
 		this.transform = this.sceneManager.transform;
 		this.space = this.sceneManager.space;
-		this.measurementHelpers = this.sceneManager.measurements;
+		this.measurementManager = new MeasurementManager(
+			this.sceneManager.measurements,
+			() => ({
+				canvas: this.canvas,
+				camera: this.camera,
+				space: this.space,
+			}),
+		);
 
 		this.rendererManager = new RendererManager(
 			this.camera,
@@ -726,7 +640,7 @@ export class DT3DCard extends LitElement {
 
 		this.sidebar.addEventListener("measurement-mode-selected", (e: any) => {
 			const mode = e.detail.mode as "distance" | "angle" | "none";
-			this.setMeasurementMode(mode);
+			this.measurementManager?.setMode(mode);
 		});
 
 		this.sidebar.addEventListener("add-object", (e: any) => {

--- a/frontend/src/components/measurement-manager.ts
+++ b/frontend/src/components/measurement-manager.ts
@@ -1,0 +1,88 @@
+import type { Camera } from "three";
+import { Group, Raycaster, Vector2, Vector3 } from "three";
+import { AngleMeasurement } from "../objects/measurement/angle.js";
+import { DistanceMeasurement } from "../objects/measurement/distance.js";
+import { Marker } from "../objects/measurement/marker.js";
+
+type MeasurementMode = "none" | "distance" | "angle";
+
+type MeasurementContext = {
+	canvas: HTMLCanvasElement | null;
+	camera: Camera | null;
+	space: Group | null;
+};
+
+export class MeasurementManager {
+	private mode: MeasurementMode = "none";
+	private points: Vector3[] = [];
+	private helpers: Group;
+	private raycaster = new Raycaster();
+	private pointer = new Vector2();
+	private getContext: () => MeasurementContext;
+
+	constructor(helpers: Group, getContext: () => MeasurementContext) {
+		this.helpers = helpers;
+		this.getContext = getContext;
+	}
+
+	setMode(mode: MeasurementMode): void {
+		this.mode = mode;
+		this.clear();
+	}
+
+	clear(): void {
+		this.points = [];
+		this.helpers.clear();
+	}
+
+	handleClick(event: MouseEvent): boolean {
+		if (this.mode === "none") {
+			return false;
+		}
+
+		const { canvas, camera, space } = this.getContext();
+		if (!canvas || !camera || !space) {
+			return true;
+		}
+
+		const rect = canvas.getBoundingClientRect();
+		this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+		this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+		this.raycaster.setFromCamera(this.pointer, camera);
+
+		const intersects = this.raycaster.intersectObjects(space.children, true);
+		const point = intersects[0]?.point;
+
+		if (!point) {
+			return true;
+		}
+
+		this.addPoint(point);
+		return true;
+	}
+
+	private addPoint(point: Vector3): void {
+		this.points.push(point.clone());
+
+		if (this.mode === "distance" && this.points.length === 2) {
+			const points = [...this.points];
+			this.helpers.clear();
+			this.helpers.add(new DistanceMeasurement(points));
+			this.points = [];
+			return;
+		}
+
+		if (this.mode === "angle" && this.points.length === 3) {
+			const points = [...this.points];
+			this.helpers.clear();
+			this.helpers.add(new AngleMeasurement(points));
+			this.points = [];
+			return;
+		}
+
+		this.helpers.clear();
+		this.points.forEach((markerPoint) => {
+			this.helpers.add(new Marker(markerPoint));
+		});
+	}
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity in `DT3DCard` by moving measurement state and click/raycast logic out of the card.
- Encapsulate measurement behavior (modes, selected points, helper rendering) for clarity and potential reuse.
- Make measurement logic easier to maintain and test by providing a single focused component.

### Description
- Add `frontend/src/components/measurement-manager.ts` implementing `MeasurementManager` that manages measurement `mode`, selected `points`, raycasting, and rendering helpers via a `getContext` callback.
- Update `DT3DCard` to remove internal measurement state and delegate measurement interactions to a new `measurementManager` instance created with `this.sceneManager.measurements` and a context provider returning `canvas`, `camera`, and `space`.
- Wire click handling so `handleCanvasClick` calls `measurementManager.handleClick(event)` and short-circuits when measurement mode handled, and wire sidebar events to call `measurementManager.setMode(mode)`.
- Remove direct imports/usages of `Marker`, `AngleMeasurement`, and `DistanceMeasurement` from `card.ts` and keep those in the new manager file.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b5c6e8dc8332ae393863a951b79e)