### PR TITLE
Present Add mesh as a floating grid menu to the right

### DIFF
--- a/frontend/src/components/side-bar/side-bar.css
+++ b/frontend/src/components/side-bar/side-bar.css
@@ -85,6 +85,7 @@ button:active {
 
 .mesh-submenu {
 	margin-bottom: 8px;
+	position: relative;
 }
 
 .mesh-submenu summary {
@@ -119,12 +120,25 @@ button:active {
 }
 
 .mesh-submenu-items {
-	margin-top: 8px;
+	position: absolute;
+	top: 0;
+	left: calc(100% + 8px);
+	display: grid;
+	grid-template-columns: repeat(2, minmax(90px, 1fr));
+	gap: 8px;
+	padding: 10px;
+	background: color-mix(in srgb, var(--ha-color-neutral-10) 85%, transparent);
+	border-radius: 8px;
+	box-shadow: 0 8px 16px
+		color-mix(in srgb, var(--ha-color-neutral-10) 30%, transparent);
+	z-index: 5;
 }
 
 .mesh-submenu-items button {
 	font-size: 0.9em;
 	background: var(--ha-color-primary-50);
+	width: 100%;
+	margin: 0;
 }
 
 .mesh-submenu-items button:hover,


### PR DESCRIPTION
### Motivation
- Replace the current downward-expanding "Add mesh" submenu with a floating, right-positioned grid to improve discoverability and avoid pushing content down.

### Description
- Make `.mesh-submenu` a positioned container by adding `position: relative`.
- Render `.mesh-submenu-items` as an absolute positioned floating panel to the right with `left: calc(100% + 8px)` and `top: 0`.
- Lay out submenu entries in a two-column grid via `display: grid` and `grid-template-columns: repeat(2, minmax(90px, 1fr))`, and add spacing, padding, background, rounded corners, shadow, and `z-index` for elevation.
- Normalize submenu button sizing by setting `width: 100%` and removing default margins for grid presentation.

### Testing
- Ran `npm install` in `frontend/` which completed successfully with no vulnerabilities found.
- Launched the dev server with `npm run dev` which started Vite and served the frontend (local and network URLs reported).
- Automated Playwright script loaded the page, clicked the "Add mesh" summary, and captured a screenshot (`artifacts/add-mesh-floating-menu.png`), indicating the floating menu is rendered as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b660ba34833285f088ca15eea21d)