### PR TITLE
Add toggleable camera-following grid and transform snapping controls

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -588,6 +588,8 @@ export class DT3DCard extends LitElement {
 				void this.spaceSync?.syncObjectUpdate(this.transform.object);
 			}
 		});
+		this.sceneManager.setGridEnabled(this.sidebar.gridEnabled);
+		this.sceneManager.setTransformSnapEnabled(this.sidebar.gridSnapEnabled);
 
 		this.scene = this.sceneManager.scene;
 		this.camera = this.sceneManager.camera;
@@ -641,6 +643,16 @@ export class DT3DCard extends LitElement {
 		this.sidebar.addEventListener("measurement-mode-selected", (e: any) => {
 			const mode = e.detail.mode as "distance" | "angle" | "none";
 			this.measurementManager?.setMode(mode);
+		});
+
+		this.sidebar.addEventListener("grid-visibility-toggle", (e: any) => {
+			const enabled = e.detail.enabled as boolean;
+			this.sceneManager.setGridEnabled(enabled);
+		});
+
+		this.sidebar.addEventListener("grid-snap-toggle", (e: any) => {
+			const enabled = e.detail.enabled as boolean;
+			this.sceneManager.setTransformSnapEnabled(enabled);
 		});
 
 		this.sidebar.addEventListener("add-object", (e: any) => {

--- a/frontend/src/components/scene.ts
+++ b/frontend/src/components/scene.ts
@@ -3,6 +3,7 @@ import {
 	BoxGeometry,
 	DirectionalLight,
 	Group,
+	GridHelper,
 	MOUSE,
 	OrthographicCamera,
 	MathUtils,
@@ -82,6 +83,21 @@ export class SceneManager {
 	 */
 	public transform: TransformControls = null;
 
+	/**
+	 * Helper grid for alignment.
+	 */
+	private grid: GridHelper | null = null;
+
+	/**
+	 * Snap size for grid-aligned transforms.
+	 */
+	private gridSnapSize = 0.5;
+
+	/**
+	 * Grid visibility toggle.
+	 */
+	private gridEnabled = true;
+
 	constructor(canvas: HTMLCanvasElement, height: number, width: number,) {
 		this.scene = new Scene();
 
@@ -104,12 +120,70 @@ export class SceneManager {
 		this.controls = new OrbitControls(this.camera, canvas);
 		this.controls.enableDamping = true;
 		this.controls.dampingFactor = 0.05;
+		this.controls.addEventListener("change", () => {
+			this.updateGridPosition();
+		});
 
 		this.transform = new TransformControls(this.camera, canvas);
 		this.transform.addEventListener("dragging-changed", (event: any) => {
 			this.controls.enabled = !event.value;
 		});
 		this.scene.add(this.transform.getHelper());
+
+		this.createGrid();
+	}
+
+	/**
+	 * Enable or disable the grid helper.
+	 */
+	public setGridEnabled(enabled: boolean): void {
+		this.gridEnabled = enabled;
+		if (this.grid) {
+			this.grid.visible = enabled;
+			if (enabled) {
+				this.updateGridPosition();
+			}
+		}
+	}
+
+	/**
+	 * Enable or disable snapping for transform controls.
+	 */
+	public setTransformSnapEnabled(enabled: boolean): void {
+		if (enabled) {
+			this.transform.setTranslationSnap(this.gridSnapSize);
+			this.transform.setRotationSnap(MathUtils.degToRad(15));
+			this.transform.setScaleSnap(0.1);
+		} else {
+			this.transform.setTranslationSnap(null);
+			this.transform.setRotationSnap(null);
+			this.transform.setScaleSnap(null);
+		}
+	}
+
+	/**
+	 * Create the grid helper and add it to the scene.
+	 */
+	private createGrid(): void {
+		if (this.grid) {
+			return;
+		}
+
+		this.grid = new GridHelper(200, 200, 0x7d7d7d, 0x4a4a4a);
+		this.grid.visible = this.gridEnabled;
+		this.scene.add(this.grid);
+		this.updateGridPosition();
+	}
+
+	/**
+	 * Keep the grid centered on the camera to simulate infinite plane.
+	 */
+	private updateGridPosition(): void {
+		if (!this.grid || !this.gridEnabled) {
+			return;
+		}
+
+		this.grid.position.set(this.camera.position.x, 0, this.camera.position.z);
 	}
 
 	public createDefaultScene(): void {
@@ -197,6 +271,7 @@ export class SceneManager {
 		this.controls.update();
 
 		this.transform.camera = this.camera;
+		this.updateGridPosition();
 		
 		this.updateSize(this.width, this.height);
 	}

--- a/frontend/src/components/side-bar/side-bar.css
+++ b/frontend/src/components/side-bar/side-bar.css
@@ -71,7 +71,8 @@ button {
 		color-mix(in srgb, var(--ha-color-neutral-10) 20%, transparent);
 }
 
-.transform-btn.selected {
+.transform-btn.selected,
+.toggle-btn.selected {
 	background: var(--ha-color-primary-30);
 }
 

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -22,6 +22,8 @@ export class DT3DSidebar extends LitElement {
 	static properties = {
 		collapsed: { type: Boolean, reflect: true },
 		transformTool: { type: String },
+		gridEnabled: { type: Boolean },
+		gridSnapEnabled: { type: Boolean },
 	};
 
 	/**
@@ -40,6 +42,16 @@ export class DT3DSidebar extends LitElement {
 	 * The selected transform tool.
 	 */
 	public transformTool: TransformOptions = "translate";
+
+	/**
+	 * Toggle grid visibility.
+	 */
+	public gridEnabled = true;
+
+	/**
+	 * Toggle snapping transforms to the grid.
+	 */
+	public gridSnapEnabled = false;
 
 	public disconnectedCallback(): void {
 		this.destroyTooltips();
@@ -106,6 +118,34 @@ export class DT3DSidebar extends LitElement {
 		this.dispatchEvent(
 			new CustomEvent("measurement-mode-selected", {
 				detail: { mode },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	/**
+	 * Toggle grid visibility.
+	 */
+	private handleGridToggle() {
+		this.gridEnabled = !this.gridEnabled;
+		this.dispatchEvent(
+			new CustomEvent("grid-visibility-toggle", {
+				detail: { enabled: this.gridEnabled },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	/**
+	 * Toggle grid snapping for transform controls.
+	 */
+	private handleGridSnapToggle() {
+		this.gridSnapEnabled = !this.gridSnapEnabled;
+		this.dispatchEvent(
+			new CustomEvent("grid-snap-toggle", {
+				detail: { enabled: this.gridSnapEnabled },
 				bubbles: true,
 				composed: true,
 			}),
@@ -184,6 +224,20 @@ export class DT3DSidebar extends LitElement {
 					data-tooltip="Disable transform controls"
 					aria-label="Disable transform controls">
 					<ha-icon icon="mdi:cursor-default-outline"></ha-icon>
+				</button>
+				<button
+					@click=${() => this.handleGridSnapToggle()}
+					class=${`toggle-btn ${this.gridSnapEnabled ? "selected" : ""}`.trim()}
+					data-tooltip="Snap transforms to grid"
+					aria-label="Snap transforms to grid">
+					<ha-icon icon="mdi:magnet"></ha-icon>
+				</button>
+				<button
+					@click=${() => this.handleGridToggle()}
+					class=${`toggle-btn ${this.gridEnabled ? "selected" : ""}`.trim()}
+					data-tooltip="Toggle grid"
+					aria-label="Toggle grid">
+					<ha-icon icon="mdi:grid"></ha-icon>
 				</button>
 			</div>
 			<div class="sidebar-section">


### PR DESCRIPTION
### Motivation
- Provide a grid alignment helper and snapping controls so transform edits can be locked to a grid and the grid can be enabled/disabled.
- Make the grid appear infinite by keeping it centered on the camera so users can always align objects regardless of camera movement.

### Description
- Added a `GridHelper` to `SceneManager` with fields `grid`, `gridSnapSize`, and `gridEnabled`, plus helper methods `createGrid()`, `updateGridPosition()`, `setGridEnabled()` and `setTransformSnapEnabled()` in `frontend/src/components/scene.ts`.
- Hooked `OrbitControls` change events to call `updateGridPosition()` so the grid follows the camera, and ensured the grid recenters when camera mode changes.
- Added two sidebar toggles (`gridEnabled` and `gridSnapEnabled`) and UI buttons for toggling grid visibility and transform snapping in `frontend/src/components/side-bar/side-bar.ts` and styles in `side-bar.css`.
- Wired the new sidebar events into the card so the scene manager receives initial settings and runtime toggle events in `frontend/src/components/card.ts`.

### Testing
- Started the frontend dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready (success).
- Ran a headless Playwright script that visited `http://127.0.0.1:4173/`, captured a screenshot `artifacts/grid-controls.png`, and completed successfully.
- No unit tests were added; no additional automated test failures encountered during the manual/dev run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697498365cc48332ac425931e8699a0a)