### PR TITLE
Add Wall/Window/Door objects, carve wall geometry for openings, and wall drawing tools

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -23,6 +23,7 @@ import {
 	ShapeGeometry,
 	SphereGeometry,
 	Vector2,
+	Vector3,
 	Group,
 	TetrahedronGeometry,
 	TorusGeometry,
@@ -57,6 +58,7 @@ import { DT3DCameraToggle } from "./camera-toggle.js";
 import { SpaceApi } from "../utils/space-api.js";
 import { SpaceSync } from "../utils/space-sync.js";
 import { MeasurementManager } from "./measurement-manager.js";
+import { WallObject } from "../objects/wall.js";
 
 @customElement("dt3d-card")
 export class DT3DCard extends LitElement {
@@ -121,6 +123,14 @@ export class DT3DCard extends LitElement {
 	 * Handles measurement interactions and helper rendering.
 	 */
 	private measurementManager: MeasurementManager | null = null;
+
+	/**
+	 * Wall tool state.
+	 */
+	private wallToolMode: "none" | "wall" | "door" | "window" = "none";
+	private wallDraftStart: Vector3 | null = null;
+	private wallDraft: WallObject | null = null;
+	private lastSelectedObject: Object3D | null = null;
 
 	/**
 	 * Raycaster for interaction with the scene.
@@ -406,8 +416,13 @@ export class DT3DCard extends LitElement {
 			return;
 		}
 
+		if (this.handleWallClick(event)) {
+			return;
+		}
+
 		// Pick object and trigger click interaction
 		const { object } = this.pickObjectFromEvent(event);
+		this.lastSelectedObject = object;
 		object?.onInteraction({
 			type: "click",
 			event: event,
@@ -421,6 +436,10 @@ export class DT3DCard extends LitElement {
 	 * @param event - Mouse event 
 	 */
 	private handlePointerMove(event: MouseEvent): void {
+		if (this.wallToolMode === "wall") {
+			this.handleWallPointerMove(event);
+		}
+
 		const { object } = this.pickObjectFromEvent(event);
 		if (object === this.hoveredObject) {
 			return;
@@ -491,6 +510,124 @@ export class DT3DCard extends LitElement {
 		}
 
 		return { object: null, intersection: null };
+	}
+
+	private handleWallClick(event: MouseEvent): boolean {
+		if (this.wallToolMode === "door" || this.wallToolMode === "window") {
+			const selectedWall = this.resolveSelectedWall();
+			if (!selectedWall) {
+				return false;
+			}
+
+			const added = this.wallToolMode === "door"
+				? selectedWall.addDoor()
+				: selectedWall.addWindow();
+			this.attachTransform(added);
+			this.tree.updateTreeFromScene(this.space);
+			void this.spaceSync?.syncObjectHierarchyCreate(added);
+			return true;
+		}
+
+		if (this.wallToolMode !== "wall") {
+			return false;
+		}
+
+		const intersection = this.pickPointFromEvent(event);
+		if (!intersection) {
+			return true;
+		}
+
+		if (!this.wallDraftStart) {
+			this.wallDraftStart = intersection.clone();
+			this.createWallDraft(this.wallDraftStart);
+			return true;
+		}
+
+		this.finalizeWall(intersection);
+		return true;
+	}
+
+	private handleWallPointerMove(event: MouseEvent): void {
+		if (!this.wallDraftStart || !this.wallDraft) {
+			return;
+		}
+
+		const intersection = this.pickPointFromEvent(event);
+		if (!intersection) {
+			return;
+		}
+
+		this.wallDraft.setFromPoints(this.wallDraftStart, intersection);
+		this.wallDraft.updateWallLabel();
+	}
+
+	private createWallDraft(start: Vector3): void {
+		this.wallDraft = new WallObject();
+		this.wallDraft.internal = true;
+		this.wallDraft.name = "Wall Draft";
+		this.wallDraft.setFromPoints(start, start.clone().add(new Vector3(1, 0, 0)));
+		this.wallDraft.updateWallLabel();
+		this.sceneManager.measurements.add(this.wallDraft);
+	}
+
+	private finalizeWall(end: Vector3): void {
+		if (!this.wallDraftStart || !this.wallDraft) {
+			return;
+		}
+
+		const wall = new WallObject({
+			length: this.wallDraft.length,
+			height: this.wallDraft.height,
+			thickness: this.wallDraft.thickness,
+		});
+		wall.position.copy(this.wallDraft.position);
+		wall.rotation.copy(this.wallDraft.rotation);
+
+		this.sceneManager.measurements.remove(this.wallDraft);
+		this.clearWallDraft();
+
+		this.addToScene(wall);
+		this.lastSelectedObject = wall;
+	}
+
+	private clearWallDraft(): void {
+		if (this.wallDraft) {
+			this.sceneManager.measurements.remove(this.wallDraft);
+		}
+		this.wallDraft = null;
+		this.wallDraftStart = null;
+	}
+
+	private resolveSelectedWall(): WallObject | null {
+		if (this.lastSelectedObject instanceof WallObject) {
+			return this.lastSelectedObject;
+		}
+
+		if (this.lastSelectedObject) {
+			const parentWall = this.lastSelectedObject.parent;
+			if (parentWall instanceof WallObject) {
+				return parentWall;
+			}
+		}
+
+		return null;
+	}
+
+	private pickPointFromEvent(event: MouseEvent): Vector3 | null {
+		if (!this.canvas || !this.camera || !this.space) {
+			return null;
+		}
+
+		const rect = this.canvas.getBoundingClientRect();
+		this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+		this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+		this.raycaster.setFromCamera(this.pointer, this.camera);
+
+		const intersects = this.raycaster.intersectObjects(
+			this.space.children,
+			true,
+		);
+		return intersects[0]?.point ?? null;
 	}
 
 
@@ -643,6 +780,14 @@ export class DT3DCard extends LitElement {
 			this.measurementManager?.setMode(mode);
 		});
 
+		this.sidebar.addEventListener("wall-tool-selected", (e: any) => {
+			const mode = e.detail.mode as "wall" | "door" | "window" | "none";
+			this.wallToolMode = mode;
+			if (mode !== "wall") {
+				this.clearWallDraft();
+			}
+		});
+
 		this.sidebar.addEventListener("add-object", (e: any) => {
 			const type = e.detail.type;
 
@@ -682,6 +827,7 @@ export class DT3DCard extends LitElement {
 			const object = this.space.getObjectByProperty("uuid", id);
 			if (object) {
 				this.attachTransform(object);
+				this.lastSelectedObject = object;
 			}
 		});
 
@@ -720,6 +866,7 @@ export class DT3DCard extends LitElement {
 				const target = object ?? (intersection.object as Object3D);
 				this.attachTransform(target);
 				this.tree.selectObject(target.uuid);
+				this.lastSelectedObject = target;
 			}
 
 			object?.onInteraction({

--- a/frontend/src/components/object-tree/object-inspector.ts
+++ b/frontend/src/components/object-tree/object-inspector.ts
@@ -3,6 +3,9 @@ import { customElement, property } from "lit/decorators.js";
 import { Color, Object3D } from "three";
 import { EntityObject } from "../../objects/entity-object.js";
 import { DTObject } from "../../objects/dt-object.js";
+import { WallObject } from "../../objects/wall.js";
+import { DoorObject } from "../../objects/door.js";
+import { WindowObject } from "../../objects/window.js";
 import componentStyles from "./object-inspector.css?inline";
 
 @customElement("dt3d-object-inspector")
@@ -22,6 +25,17 @@ export class DT3DObjectInspector extends LitElement {
 		return object instanceof EntityObject;
 	}
 
+	private isWallObject(object: Object3D | null): object is WallObject {
+		return object instanceof WallObject;
+	}
+
+	private isDoorObject(object: Object3D | null): object is DoorObject {
+		return object instanceof DoorObject;
+	}
+
+	private isWindowObject(object: Object3D | null): object is WindowObject {
+		return object instanceof WindowObject;
+	}
 	/**
 	 * Check if object has a material with a color.
 	 *
@@ -123,6 +137,45 @@ export class DT3DObjectInspector extends LitElement {
 		}
 
 		this.selectedObject.locked = (event.target as HTMLInputElement).checked;
+		this.dispatchUpdated();
+		this.requestUpdate();
+	}
+
+	private handleWallValueChange(
+		type: "height" | "thickness",
+		event: Event,
+	) {
+		if (!this.isWallObject(this.selectedObject) || this.isLocked()) {
+			return;
+		}
+
+		const value = parseFloat((event.target as HTMLInputElement).value);
+		if (Number.isNaN(value)) return;
+
+		if (type === "height") {
+			this.selectedObject.setHeight(value);
+		} else {
+			this.selectedObject.setThickness(value);
+		}
+
+		this.dispatchUpdated();
+		this.requestUpdate();
+	}
+
+	private handleOpenStateChange(event: Event) {
+		if (this.isLocked()) {
+			return;
+		}
+
+		const isOpen = (event.target as HTMLInputElement).checked;
+		if (this.isDoorObject(this.selectedObject)) {
+			this.selectedObject.setOpen(isOpen);
+		} else if (this.isWindowObject(this.selectedObject)) {
+			this.selectedObject.setOpen(isOpen);
+		} else {
+			return;
+		}
+
 		this.dispatchUpdated();
 		this.requestUpdate();
 	}
@@ -276,6 +329,63 @@ export class DT3DObjectInspector extends LitElement {
 		`;
 	}
 
+	private renderWallControls(locked: boolean) {
+		if (!this.isWallObject(this.selectedObject)) {
+			return null;
+		}
+
+		return html`
+			<h4>Wall</h4>
+			<div class="field">
+				<label>Height (m)</label>
+				<input
+					type="number"
+					step="0.1"
+					min="0.1"
+					.value=${this.selectedObject.height.toFixed(2)}
+					?disabled=${locked}
+					@change=${(event: Event) => this.handleWallValueChange("height", event)}
+				/>
+			</div>
+			<div class="field">
+				<label>Thickness (m)</label>
+				<input
+					type="number"
+					step="0.05"
+					min="0.05"
+					.value=${this.selectedObject.thickness.toFixed(2)}
+					?disabled=${locked}
+					@change=${(event: Event) =>
+						this.handleWallValueChange("thickness", event)}
+				/>
+			</div>
+		`;
+	}
+
+	private renderOpeningControls(locked: boolean) {
+		if (!this.isDoorObject(this.selectedObject) && !this.isWindowObject(this.selectedObject)) {
+			return null;
+		}
+
+		const isOpen = this.selectedObject?.open ?? false;
+		const label = this.isDoorObject(this.selectedObject) ? "Door" : "Window";
+
+		return html`
+			<h4>${label}</h4>
+			<div class="field">
+				<label>
+					<input
+						type="checkbox"
+						.checked=${isOpen}
+						?disabled=${locked}
+						@change=${(event: Event) => this.handleOpenStateChange(event)}
+					/>
+					Open
+				</label>
+			</div>
+		`;
+	}
+
 	public render() {
 		const locked = this.isLocked();
 		const isDTObject = this.selectedObject instanceof DTObject;
@@ -318,6 +428,8 @@ export class DT3DObjectInspector extends LitElement {
 						${this.renderVectorControls("Scale", "scale", locked)}
 						${this.renderRotationControls(locked)}
 						${this.renderMaterialControls(locked)}
+						${this.renderWallControls(locked)}
+						${this.renderOpeningControls(locked)}
 						${this.renderEntityDetails()}
 					`
 				: html`<div class="placeholder">

--- a/frontend/src/components/side-bar/side-bar.css
+++ b/frontend/src/components/side-bar/side-bar.css
@@ -83,6 +83,10 @@ button:active {
 	background: var(--ha-color-primary-40);
 }
 
+button.selected {
+	background: var(--ha-color-primary-30);
+}
+
 .mesh-submenu {
 	margin-bottom: 8px;
 	position: relative;

--- a/frontend/src/components/side-bar/side-bar.ts
+++ b/frontend/src/components/side-bar/side-bar.ts
@@ -10,6 +10,8 @@ export type TransformOptions = "translate" | "rotate" | "scale" | "none";
 
 export type MeasurementOptions = "distance" | "angle" | "none";
 
+export type WallOptions = "wall" | "door" | "window" | "none";
+
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "sidebar-collapsed";
 
 /**
@@ -105,6 +107,21 @@ export class DT3DSidebar extends LitElement {
 	private handleMeasurementSelect(mode: MeasurementOptions) {
 		this.dispatchEvent(
 			new CustomEvent("measurement-mode-selected", {
+				detail: { mode },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	/**
+	 * Select wall drawing tool.
+	 *
+	 * @param mode - Wall tool to use.
+	 */
+	private handleWallSelect(mode: WallOptions) {
+		this.dispatchEvent(
+			new CustomEvent("wall-tool-selected", {
 				detail: { mode },
 				bubbles: true,
 				composed: true,
@@ -239,6 +256,33 @@ export class DT3DSidebar extends LitElement {
 					@click=${() => this.handleMeasurementSelect("none")}
 					data-tooltip="Clear measurements"
 					aria-label="Clear measurements">
+					<ha-icon icon="mdi:cancel"></ha-icon>
+				</button>
+			</div>
+			<div class="sidebar-section">
+				<div class="sidebar-title">Walls</div>
+				<button
+					@click=${() => this.handleWallSelect("wall")}
+					data-tooltip="Draw wall"
+					aria-label="Draw wall">
+					<ha-icon icon="mdi:vector-line"></ha-icon>
+				</button>
+				<button
+					@click=${() => this.handleWallSelect("door")}
+					data-tooltip="Add door to selected wall"
+					aria-label="Add door to selected wall">
+					<ha-icon icon="mdi:door"></ha-icon>
+				</button>
+				<button
+					@click=${() => this.handleWallSelect("window")}
+					data-tooltip="Add window to selected wall"
+					aria-label="Add window to selected wall">
+					<ha-icon icon="mdi:window-closed-variant"></ha-icon>
+				</button>
+				<button
+					@click=${() => this.handleWallSelect("none")}
+					data-tooltip="Exit wall tools"
+					aria-label="Exit wall tools">
 					<ha-icon icon="mdi:cancel"></ha-icon>
 				</button>
 			</div>

--- a/frontend/src/objects/door.ts
+++ b/frontend/src/objects/door.ts
@@ -1,0 +1,89 @@
+import { Group, Mesh, MeshStandardMaterial, BoxGeometry } from "three";
+import { DTObject } from "./dt-object.js";
+
+type DoorDimensions = {
+	width: number;
+	height: number;
+	thickness: number;
+};
+
+const DEFAULT_DOOR_DIMENSIONS: DoorDimensions = {
+	width: 0.9,
+	height: 2.1,
+	thickness: 0.08,
+};
+
+const DEFAULT_DOOR_COLOR = 0x7a4e2f;
+
+export class DoorObject extends DTObject {
+	public width: number;
+	public height: number;
+	public thickness: number;
+	public open = false;
+
+	private hingeGroup: Group;
+	private doorMesh: Mesh;
+
+	constructor(
+		dimensions: Partial<DoorDimensions> = {},
+		color = DEFAULT_DOOR_COLOR,
+	) {
+		super();
+
+		this.width = dimensions.width ?? DEFAULT_DOOR_DIMENSIONS.width;
+		this.height = dimensions.height ?? DEFAULT_DOOR_DIMENSIONS.height;
+		this.thickness = dimensions.thickness ?? DEFAULT_DOOR_DIMENSIONS.thickness;
+
+		this.name = "Door";
+		this.userData.meshType = "door";
+
+		this.hingeGroup = new Group();
+		this.add(this.hingeGroup);
+
+		const material = new MeshStandardMaterial({ color });
+		this.doorMesh = new Mesh(new BoxGeometry(1, 1, 1), material);
+		this.doorMesh.name = "Door Panel";
+		this.hingeGroup.add(this.doorMesh);
+
+		this.updateGeometry();
+	}
+
+	public setOpen(isOpen: boolean): void {
+		this.open = isOpen;
+		this.hingeGroup.rotation.y = isOpen ? -Math.PI / 2 : 0;
+	}
+
+	public toggleOpen(): void {
+		this.setOpen(!this.open);
+	}
+
+	public getDoorMaterial(): MeshStandardMaterial {
+		return this.doorMesh.material as MeshStandardMaterial;
+	}
+
+	public override copy(source: this, recursive: boolean = true): this {
+		super.copy(source, recursive);
+		if (source instanceof DoorObject) {
+			this.width = source.width;
+			this.height = source.height;
+			this.thickness = source.thickness;
+			this.open = source.open;
+		}
+
+		const mesh = this.getObjectByName("Door Panel") as Mesh | null;
+		if (mesh) {
+			this.doorMesh = mesh;
+			this.updateGeometry();
+			this.setOpen(this.open);
+		}
+		return this;
+	}
+
+	private updateGeometry(): void {
+		const geometry = new BoxGeometry(this.width, this.height, this.thickness);
+		this.doorMesh.geometry.dispose();
+		this.doorMesh.geometry = geometry;
+		this.hingeGroup.position.set(-this.width / 2, this.height / 2, 0);
+		this.doorMesh.position.set(this.width / 2, 0, 0);
+	}
+}

--- a/frontend/src/objects/wall.ts
+++ b/frontend/src/objects/wall.ts
@@ -1,0 +1,244 @@
+import {
+	BoxGeometry,
+	ExtrudeGeometry,
+	Mesh,
+	MeshStandardMaterial,
+	Path,
+	Shape,
+	Vector3,
+} from "three";
+import { DTObject } from "./dt-object.js";
+import { CSSText } from "./helpers/css-text.js";
+import { getCSSVar } from "../utils/css-utils.js";
+import { DoorObject } from "./door.js";
+import { WindowObject } from "./window.js";
+
+type WallDimensions = {
+	length: number;
+	height: number;
+	thickness: number;
+};
+
+const DEFAULT_WALL_DIMENSIONS: WallDimensions = {
+	length: 2,
+	height: 2.4,
+	thickness: 0.2,
+};
+
+const DEFAULT_WALL_COLOR = 0xc9c7c2;
+
+export class WallObject extends DTObject {
+	public length: number;
+	public height: number;
+	public thickness: number;
+
+	private wallMesh: Mesh;
+	private doorCount = 0;
+	private windowCount = 0;
+	private lengthLabel: CSSText | null = null;
+	private lastOpeningsSignature = "";
+
+	constructor(dimensions: Partial<WallDimensions> = {}, color = DEFAULT_WALL_COLOR) {
+		super();
+
+		this.length = dimensions.length ?? DEFAULT_WALL_DIMENSIONS.length;
+		this.height = dimensions.height ?? DEFAULT_WALL_DIMENSIONS.height;
+		this.thickness = dimensions.thickness ?? DEFAULT_WALL_DIMENSIONS.thickness;
+
+		this.name = "Wall";
+		this.userData.meshType = "wall";
+
+		const material = new MeshStandardMaterial({ color });
+		this.wallMesh = new Mesh(new BoxGeometry(1, 1, 1), material);
+		this.wallMesh.name = "Wall Body";
+		this.wallMesh.userData.wallPart = "body";
+		this.add(this.wallMesh);
+
+		this.updateGeometry();
+	}
+
+	public setFromPoints(start: Vector3, end: Vector3): void {
+		const length = start.distanceTo(end);
+		this.setLength(length);
+
+		const midpoint = start.clone().add(end).multiplyScalar(0.5);
+		this.position.set(midpoint.x, start.y, midpoint.z);
+
+		const direction = end.clone().sub(start);
+		const angle = Math.atan2(direction.z, direction.x);
+		this.rotation.set(0, angle, 0);
+	}
+
+	public setHeight(height: number): void {
+		if (!Number.isFinite(height) || height <= 0) {
+			return;
+		}
+
+		this.height = height;
+		this.updateGeometry();
+	}
+
+	public setThickness(thickness: number): void {
+		if (!Number.isFinite(thickness) || thickness <= 0) {
+			return;
+		}
+
+		this.thickness = thickness;
+		this.updateGeometry();
+	}
+
+	public setLength(length: number): void {
+		if (!Number.isFinite(length) || length <= 0) {
+			return;
+		}
+
+		this.length = length;
+		this.updateGeometry();
+	}
+
+	public updateWallLabel(): void {
+		const labelText = `${this.length.toFixed(2)}m`;
+		if (!this.lengthLabel) {
+			this.lengthLabel = new CSSText(labelText, {
+				style: {
+					color: getCSSVar("--ha-color-primary-95"),
+					backgroundColor: getCSSVar("--ha-color-neutral-20"),
+					padding: "2px 6px",
+					borderRadius: "6px",
+				},
+			});
+			this.lengthLabel.scale.setScalar(0.25);
+			(this.lengthLabel as any).internal = true;
+			this.add(this.lengthLabel);
+		} else {
+			this.lengthLabel.setText(labelText);
+		}
+
+		this.lengthLabel.position.set(0, this.height + 0.2, 0);
+	}
+
+	public addDoor(): DoorObject {
+		this.doorCount += 1;
+		const door = new DoorObject();
+		door.name = `Door ${this.doorCount}`;
+		door.position.y = door.height / 2;
+		this.add(door);
+		this.updateGeometry();
+		return door;
+	}
+
+	public addWindow(): WindowObject {
+		this.windowCount += 1;
+		const window = new WindowObject();
+		window.name = `Window ${this.windowCount}`;
+		window.position.y = 1.2 + window.height / 2;
+		this.add(window);
+		this.updateGeometry();
+		return window;
+	}
+
+	public getWallMaterial(): MeshStandardMaterial {
+		return this.wallMesh.material as MeshStandardMaterial;
+	}
+
+	public override update(_time: number): void {
+		const signature = this.getOpeningsSignature();
+		if (signature !== this.lastOpeningsSignature) {
+			this.updateGeometry();
+		}
+	}
+
+	public override copy(source: this, recursive: boolean = true): this {
+		super.copy(source, recursive);
+		if (source instanceof WallObject) {
+			this.length = source.length;
+			this.height = source.height;
+			this.thickness = source.thickness;
+			this.doorCount = source.doorCount;
+			this.windowCount = source.windowCount;
+		}
+
+		const mesh = this.getObjectByProperty(
+			"userData.wallPart",
+			"body",
+		) as Mesh | null;
+		if (mesh) {
+			this.wallMesh = mesh;
+			this.updateGeometry();
+		}
+		return this;
+	}
+
+	private updateGeometry(): void {
+		const shape = this.createWallShape();
+		const geometry = new ExtrudeGeometry(shape, {
+			depth: this.thickness,
+			bevelEnabled: false,
+		});
+		geometry.translate(0, 0, -this.thickness / 2);
+		this.wallMesh.geometry.dispose();
+		this.wallMesh.geometry = geometry;
+		this.wallMesh.position.set(0, 0, 0);
+		if (this.lengthLabel) {
+			this.lengthLabel.position.set(0, this.height + 0.2, 0);
+		}
+		this.lastOpeningsSignature = this.getOpeningsSignature();
+	}
+
+	private createWallShape(): Shape {
+		const halfLength = this.length / 2;
+		const shape = new Shape();
+		shape.moveTo(-halfLength, 0);
+		shape.lineTo(halfLength, 0);
+		shape.lineTo(halfLength, this.height);
+		shape.lineTo(-halfLength, this.height);
+		shape.lineTo(-halfLength, 0);
+
+		for (const opening of this.getOpenings()) {
+			const { width, height, x, y } = opening;
+			const left = x - width / 2;
+			const right = x + width / 2;
+			const bottom = y - height / 2;
+			const top = y + height / 2;
+			const hole = new Path();
+			hole.moveTo(left, bottom);
+			hole.lineTo(right, bottom);
+			hole.lineTo(right, top);
+			hole.lineTo(left, top);
+			hole.lineTo(left, bottom);
+			shape.holes.push(hole);
+		}
+
+		return shape;
+	}
+
+	private getOpenings(): Array<{ width: number; height: number; x: number; y: number }> {
+		const openings: Array<{ width: number; height: number; x: number; y: number }> = [];
+		for (const child of this.children) {
+			if (child instanceof DoorObject) {
+				openings.push({
+					width: child.width,
+					height: child.height,
+					x: child.position.x,
+					y: child.position.y,
+				});
+			}
+			if (child instanceof WindowObject) {
+				openings.push({
+					width: child.width,
+					height: child.height,
+					x: child.position.x,
+					y: child.position.y,
+				});
+			}
+		}
+		return openings;
+	}
+
+	private getOpeningsSignature(): string {
+		const parts = this.getOpenings().map((opening) =>
+			[opening.width, opening.height, opening.x, opening.y].join(","),
+		);
+		return `${this.length}|${this.height}|${this.thickness}|${parts.join(";")}`;
+	}
+}

--- a/frontend/src/objects/window.ts
+++ b/frontend/src/objects/window.ts
@@ -1,0 +1,89 @@
+import { Mesh, MeshStandardMaterial, BoxGeometry } from "three";
+import { DTObject } from "./dt-object.js";
+
+type WindowDimensions = {
+	width: number;
+	height: number;
+	thickness: number;
+};
+
+const DEFAULT_WINDOW_DIMENSIONS: WindowDimensions = {
+	width: 1.2,
+	height: 1.0,
+	thickness: 0.06,
+};
+
+const DEFAULT_WINDOW_COLOR = 0x6aa6ff;
+
+export class WindowObject extends DTObject {
+	public width: number;
+	public height: number;
+	public thickness: number;
+	public open = false;
+
+	private windowMesh: Mesh;
+
+	constructor(
+		dimensions: Partial<WindowDimensions> = {},
+		color = DEFAULT_WINDOW_COLOR,
+	) {
+		super();
+
+		this.width = dimensions.width ?? DEFAULT_WINDOW_DIMENSIONS.width;
+		this.height = dimensions.height ?? DEFAULT_WINDOW_DIMENSIONS.height;
+		this.thickness = dimensions.thickness ?? DEFAULT_WINDOW_DIMENSIONS.thickness;
+
+		this.name = "Window";
+		this.userData.meshType = "window";
+
+		const material = new MeshStandardMaterial({
+			color,
+			transparent: true,
+			opacity: 0.7,
+		});
+		this.windowMesh = new Mesh(new BoxGeometry(1, 1, 1), material);
+		this.windowMesh.name = "Window Panel";
+		this.add(this.windowMesh);
+
+		this.updateGeometry();
+		this.setOpen(this.open);
+	}
+
+	public setOpen(isOpen: boolean): void {
+		this.open = isOpen;
+		this.windowMesh.position.z = isOpen ? this.thickness : 0;
+	}
+
+	public toggleOpen(): void {
+		this.setOpen(!this.open);
+	}
+
+	public getWindowMaterial(): MeshStandardMaterial {
+		return this.windowMesh.material as MeshStandardMaterial;
+	}
+
+	public override copy(source: this, recursive: boolean = true): this {
+		super.copy(source, recursive);
+		if (source instanceof WindowObject) {
+			this.width = source.width;
+			this.height = source.height;
+			this.thickness = source.thickness;
+			this.open = source.open;
+		}
+
+		const mesh = this.getObjectByName("Window Panel") as Mesh | null;
+		if (mesh) {
+			this.windowMesh = mesh;
+			this.updateGeometry();
+			this.setOpen(this.open);
+		}
+		return this;
+	}
+
+	private updateGeometry(): void {
+		const geometry = new BoxGeometry(this.width, this.height, this.thickness);
+		this.windowMesh.geometry.dispose();
+		this.windowMesh.geometry = geometry;
+		this.windowMesh.position.set(0, this.height / 2, 0);
+	}
+}

--- a/frontend/src/utils/space-sync.ts
+++ b/frontend/src/utils/space-sync.ts
@@ -1,9 +1,11 @@
-import { Group, MeshStandardMaterial, Object3D } from "three";
-import type { Mesh } from "three";
+import { BoxGeometry, Group, Mesh, MeshStandardMaterial, Object3D } from "three";
 import type { SceneManager } from "../components/scene.js";
 import type { DT3DTree } from "../components/object-tree/object-tree.js";
 import { createMeshObject } from "../components/mesh-options.js";
 import { DTObject } from "../objects/dt-object.js";
+import { WallObject } from "../objects/wall.js";
+import { DoorObject } from "../objects/door.js";
+import { WindowObject } from "../objects/window.js";
 import { EntityObject } from "../objects/entity-object.js";
 import {
 	SpaceApi,
@@ -157,8 +159,46 @@ export class SpaceSync {
 			}
 
 			const color = typeof data.color === "string" ? parseInt(data.color, 16) : 0xffffff;
-			const material = new MeshStandardMaterial({ color });
-			object = createMeshObject(meshType, material);
+			if (meshType === "wall") {
+				const wallData = data.wall as { length?: number; height?: number; thickness?: number } | undefined;
+				object = new WallObject(
+					{
+						length: wallData?.length,
+						height: wallData?.height,
+						thickness: wallData?.thickness,
+					},
+					color,
+				);
+			} else if (meshType === "door" || meshType === "window") {
+				const dims = data.dimensions as { width?: number; height?: number; thickness?: number } | undefined;
+				const openState = data.open === true;
+				if (meshType === "door") {
+					const door = new DoorObject(
+						{
+							width: dims?.width,
+							height: dims?.height,
+							thickness: dims?.thickness,
+						},
+						color,
+					);
+					door.setOpen(openState);
+					object = door;
+				} else {
+					const windowObj = new WindowObject(
+						{
+							width: dims?.width,
+							height: dims?.height,
+							thickness: dims?.thickness,
+						},
+						color,
+					);
+					windowObj.setOpen(openState);
+					object = windowObj;
+				}
+			} else {
+				const material = new MeshStandardMaterial({ color });
+				object = createMeshObject(meshType, material);
+			}
 			if (object) {
 				object.userData.meshType = meshType;
 			}
@@ -220,6 +260,44 @@ export class SpaceSync {
 		if (object instanceof EntityObject) {
 			type = "entity";
 			data.entityId = object.entityId;
+		} else if (object instanceof WallObject) {
+			type = "mesh";
+			data.meshType = "wall";
+			data.wall = {
+				length: object.length,
+				height: object.height,
+				thickness: object.thickness,
+			};
+			const material = object.getWallMaterial();
+			if (material?.color?.getHexString) {
+				data.color = material.color.getHexString();
+			}
+		} else if (object instanceof DoorObject) {
+			type = "mesh";
+			data.meshType = "door";
+			data.open = object.open;
+			data.dimensions = {
+				width: object.width,
+				height: object.height,
+				thickness: object.thickness,
+			};
+			const material = object.getDoorMaterial();
+			if (material?.color?.getHexString) {
+				data.color = material.color.getHexString();
+			}
+		} else if (object instanceof WindowObject) {
+			type = "mesh";
+			data.meshType = "window";
+			data.open = object.open;
+			data.dimensions = {
+				width: object.width,
+				height: object.height,
+				thickness: object.thickness,
+			};
+			const material = object.getWindowMaterial();
+			if (material?.color?.getHexString) {
+				data.color = material.color.getHexString();
+			}
 		} else {
 			const meshType = this.resolveMeshType(object);
 			if (meshType) {
@@ -229,6 +307,15 @@ export class SpaceSync {
 				const material = (object as Mesh).material as any;
 				if (material?.color?.getHexString) {
 					data.color = material.color.getHexString();
+				}
+
+				if (object instanceof Mesh && object.geometry instanceof BoxGeometry) {
+					const params = object.geometry.parameters as { width?: number; height?: number; depth?: number };
+					data.dimensions = {
+						width: params?.width,
+						height: params?.height,
+						depth: params?.depth,
+					};
 				}
 			}
 		}


### PR DESCRIPTION
### Motivation
- Treat doors and windows as first-class `DoorObject`/`WindowObject` children of a `WallObject` so openings can be positioned, toggled, and persisted independently.
- Update wall geometry to make room for openings by carving holes in the wall shape so openings physically cut through the wall mesh.
- Provide interactive wall creation and quick workflows to add doors/windows to the nearest/selected wall from the UI so editing feels natural.

### Description
- Added `WallObject`, `DoorObject`, and `WindowObject` under `frontend/src/objects/` with dedicated geometry, material accessors, dimension fields, `open` state and copy/update logic, and `setOpen`/`toggleOpen` methods.
- Replaced box-based wall body with an extruded `Shape` in `WallObject` and build `shape.holes` from child openings using `ExtrudeGeometry` so the wall mesh is carved to accommodate openings; added `getOpeningsSignature` and an `update` hook to rebuild geometry when openings move/change.
- Implemented wall tools in the UI: added wall tool state, drafting, finalize/clear logic, point picking helpers and placement flows in `frontend/src/components/card.ts`, and added sidebar buttons/events (`wall-tool-selected`) in `frontend/src/components/side-bar/side-bar.ts`/CSS.
- Extended inspector controls in `frontend/src/components/object-tree/object-inspector.ts` to edit wall `height`/`thickness` and to toggle door/window `open` state, and updated `frontend/src/utils/space-sync.ts` to serialize/deserialize `wall`, `door`, and `window` payloads (dimensions and `open` flags) when syncing with the API.

### Testing
- No automated tests were executed for this change; the patch is feature work only and requires a dev server run and interactive validation (not run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69749888b0ec8332b1523248241e818f)