### PR TITLE
Add dynamic-form component and refactor object inspector to use it

### DIFF
--- a/frontend/src/components/dynamic-form.css
+++ b/frontend/src/components/dynamic-form.css
@@ -1,0 +1,63 @@
+:host {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.field {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 8px;
+	gap: 4px;
+}
+
+.field label {
+	font-size: 12px;
+	color: var(--ha-color-neutral-80);
+}
+
+.field input {
+	background: color-mix(in srgb, var(--ha-color-neutral-10) 95%, transparent);
+	border: 1px solid
+		color-mix(in srgb, var(--ha-color-neutral-30) 80%, transparent);
+	border-radius: 4px;
+	padding: 6px 8px;
+	color: var(--ha-color-neutral-90);
+}
+
+.group-row {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 6px;
+}
+
+.group-row label {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	font-size: 12px;
+	color: var(--ha-color-neutral-80);
+}
+
+.group-row input {
+	width: 100%;
+	padding: 6px 8px;
+	box-sizing: border-box;
+	border-radius: 4px;
+	border: 1px solid
+		color-mix(in srgb, var(--ha-color-neutral-30) 80%, transparent);
+	background: color-mix(in srgb, var(--ha-color-neutral-10) 95%, transparent);
+	color: var(--ha-color-neutral-90);
+}
+
+.color-input {
+	width: 100%;
+	height: 36px;
+	padding: 0 6px;
+	box-sizing: border-box;
+	cursor: pointer;
+}
+
+.info-input {
+	opacity: 0.7;
+}

--- a/frontend/src/components/dynamic-form.ts
+++ b/frontend/src/components/dynamic-form.ts
@@ -1,0 +1,259 @@
+import { LitElement, html, unsafeCSS } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import componentStyles from "./dynamic-form.css?inline";
+
+export type DynamicFieldType =
+	| "Vector3"
+	| "string"
+	| "number"
+	| "boolean"
+	| "color"
+	| "info";
+
+export type DynamicFormField = {
+	label: string;
+	attribute: string;
+	type: DynamicFieldType;
+	tooltip?: string;
+	editable: boolean;
+	enabled: boolean;
+};
+
+export type DynamicFormChangeDetail = {
+	attribute: string;
+	value: unknown;
+	type: DynamicFieldType;
+};
+
+type VectorValue = {
+	x: number;
+	y: number;
+	z: number;
+	isEuler?: boolean;
+};
+
+@customElement("dynamic-form")
+export class DynamicForm extends LitElement {
+	static styles = unsafeCSS(componentStyles);
+
+	@property({ attribute: false })
+	public fields: DynamicFormField[] = [];
+
+	@property({ attribute: false })
+	public data: Record<string, unknown> | null = null;
+
+	private getFieldValue(field: DynamicFormField): unknown {
+		if (!this.data) return null;
+		const path = field.attribute.split(".");
+		let current: any = this.data;
+		for (const segment of path) {
+			if (current == null) {
+				return null;
+			}
+			current = current[segment];
+		}
+		return current ?? null;
+	}
+
+	private formatNumber(value: number, decimals = 2) {
+		if (Number.isNaN(value)) return "";
+		return value.toFixed(decimals);
+	}
+
+	private getVectorDisplayValue(field: DynamicFormField): VectorValue | null {
+		const value = this.getFieldValue(field);
+		if (!value || typeof value !== "object") return null;
+		const vector = value as VectorValue;
+		if (typeof vector.x !== "number") return null;
+
+		const isEuler = Boolean((vector as any).isEuler);
+		const factor = isEuler ? 180 / Math.PI : 1;
+
+		return {
+			x: vector.x * factor,
+			y: vector.y * factor,
+			z: vector.z * factor,
+			isEuler,
+		};
+	}
+
+	private getColorValue(field: DynamicFormField): string {
+		const value = this.getFieldValue(field);
+		if (!value) return "#000000";
+		if (typeof value === "string") {
+			return value;
+		}
+		if (typeof (value as any).getHexString === "function") {
+			return `#${(value as any).getHexString()}`;
+		}
+		return "#000000";
+	}
+
+	private dispatchFieldChange(
+		attribute: string,
+		type: DynamicFieldType,
+		value: unknown,
+	) {
+		this.dispatchEvent(
+			new CustomEvent<DynamicFormChangeDetail>("field-change", {
+				detail: { attribute, value, type },
+				bubbles: true,
+				composed: true,
+			}),
+		);
+	}
+
+	private renderVectorField(field: DynamicFormField) {
+		const vector = this.getVectorDisplayValue(field);
+		if (!vector) return null;
+
+		return html`
+			<div class="field">
+				<label title=${field.tooltip ?? ""}>${field.label}</label>
+				<div class="group-row">
+					${(["x", "y", "z"] as const).map(
+						(axis) => html`
+							<label>
+								${axis.toUpperCase()}
+								<input
+									type="number"
+									step="0.01"
+									.value=${this.formatNumber(vector[axis])}
+									?disabled=${!field.editable || !field.enabled}
+									@change=${(event: Event) => {
+										const rawValue = parseFloat(
+											(event.target as HTMLInputElement).value,
+										);
+										if (Number.isNaN(rawValue)) return;
+										this.dispatchFieldChange(
+											`${field.attribute}.${axis}`,
+											field.type,
+											rawValue,
+										);
+									}}
+								/>
+							</label>
+						`,
+					)}
+				</div>
+			</div>
+		`;
+	}
+
+	private renderField(field: DynamicFormField) {
+		if (!field.enabled) {
+			return null;
+		}
+
+		switch (field.type) {
+			case "Vector3":
+				return this.renderVectorField(field);
+			case "boolean": {
+				const value = Boolean(this.getFieldValue(field));
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>
+							<input
+								type="checkbox"
+								.checked=${value}
+								?disabled=${!field.editable}
+								@change=${(event: Event) =>
+									this.dispatchFieldChange(
+										field.attribute,
+										field.type,
+										(event.target as HTMLInputElement).checked,
+									)}
+							/>
+							${field.label}
+						</label>
+					</div>
+				`;
+			}
+			case "color": {
+				const value = this.getColorValue(field);
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>${field.label}</label>
+						<input
+							type="color"
+							class="color-input"
+							.value=${value}
+							?disabled=${!field.editable}
+							@input=${(event: Event) =>
+								this.dispatchFieldChange(
+									field.attribute,
+									field.type,
+									(event.target as HTMLInputElement).value,
+								)}
+						/>
+					</div>
+				`;
+			}
+			case "info": {
+				const value = this.getFieldValue(field);
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>${field.label}</label>
+						<input
+							type="text"
+							class="info-input"
+							.value=${value == null ? "" : String(value)}
+							readonly
+							disabled
+						/>
+					</div>
+				`;
+			}
+			case "number": {
+				const value = Number(this.getFieldValue(field) ?? 0);
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>${field.label}</label>
+						<input
+							type="number"
+							step="0.01"
+							.value=${this.formatNumber(value)}
+							?disabled=${!field.editable}
+							@change=${(event: Event) => {
+								const rawValue = parseFloat(
+									(event.target as HTMLInputElement).value,
+								);
+								if (Number.isNaN(rawValue)) return;
+								this.dispatchFieldChange(
+									field.attribute,
+									field.type,
+									rawValue,
+								);
+							}}
+						/>
+					</div>
+				`;
+			}
+			case "string": {
+				const value = this.getFieldValue(field);
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>${field.label}</label>
+						<input
+							type="text"
+							.value=${value == null ? "" : String(value)}
+							?disabled=${!field.editable}
+							@input=${(event: Event) =>
+								this.dispatchFieldChange(
+									field.attribute,
+									field.type,
+									(event.target as HTMLInputElement).value,
+								)}
+						/>
+					</div>
+				`;
+			}
+			default:
+				return null;
+		}
+	}
+
+	public render() {
+		return html`${this.fields.map((field) => this.renderField(field))}`;
+	}
+}

--- a/frontend/src/components/object-tree/object-inspector.ts
+++ b/frontend/src/components/object-tree/object-inspector.ts
@@ -7,6 +7,11 @@ import { WallObject } from "../../objects/wall.js";
 import { DoorObject } from "../../objects/door.js";
 import { WindowObject } from "../../objects/window.js";
 import componentStyles from "./object-inspector.css?inline";
+import "../dynamic-form.js";
+import type {
+	DynamicFormChangeDetail,
+	DynamicFormField,
+} from "../dynamic-form.js";
 
 @customElement("dt3d-object-inspector")
 export class DT3DObjectInspector extends LitElement {
@@ -70,244 +75,153 @@ export class DT3DObjectInspector extends LitElement {
 		);
 	}
 
-	private handleNameChange(event: Event) {
-		if (!this.selectedObject || this.isLocked()) return;
+	private setNestedAttribute(target: any, attribute: string, value: unknown) {
+		const keys = attribute.split(".");
+		let current = target;
+		for (let i = 0; i < keys.length - 1; i += 1) {
+			if (current == null) return;
+			current = current[keys[i]];
+		}
 
-		const value = (event.target as HTMLInputElement).value;
-		this.selectedObject.name = value;
-		this.dispatchUpdated();
+		if (current == null) return;
+		current[keys[keys.length - 1]] = value;
 	}
 
-	/**
-	 *
-	 * @param type
-	 * @param axis
-	 * @param event
-	 * @returns
-	 */
-	private handleVectorChange(
-		type: "position" | "scale",
-		axis: "x" | "y" | "z",
-		event: Event,
-	) {
-		if (!this.selectedObject || this.isLocked()) return;
+	private handleFormFieldChange(event: CustomEvent<DynamicFormChangeDetail>) {
+		if (!this.selectedObject) return;
 
-		const value = parseFloat((event.target as HTMLInputElement).value);
-		if (Number.isNaN(value)) return;
+		const { attribute, value } = event.detail;
+		if (this.isLocked() && attribute !== "locked") {
+			return;
+		}
 
-		if (type === "position") {
-			this.selectedObject.position[axis] = value;
+		if (attribute === "locked") {
+			if (this.selectedObject instanceof DTObject) {
+				this.selectedObject.locked = Boolean(value);
+			}
+		} else if (attribute.startsWith("rotation.")) {
+			const axis = attribute.split(".")[1] as "x" | "y" | "z";
+			const rawValue = Number(value);
+			if (Number.isNaN(rawValue)) return;
+			this.selectedObject.rotation[axis] = (rawValue * Math.PI) / 180;
+		} else if (attribute === "material.color") {
+			if (!this.hasEditableColor(this.selectedObject)) {
+				return;
+			}
+			const colorValue = String(value);
+			if (!/^#[0-9a-fA-F]{6}$/.test(colorValue)) {
+				return;
+			}
+			this.selectedObject.material.color.set(colorValue);
+		} else if (attribute === "height" || attribute === "thickness") {
+			if (!this.isWallObject(this.selectedObject)) {
+				return;
+			}
+			const rawValue = Number(value);
+			if (Number.isNaN(rawValue)) return;
+			if (attribute === "height") {
+				this.selectedObject.setHeight(rawValue);
+			} else {
+				this.selectedObject.setThickness(rawValue);
+			}
+		} else if (attribute === "open") {
+			if (this.isDoorObject(this.selectedObject)) {
+				this.selectedObject.setOpen(Boolean(value));
+			} else if (this.isWindowObject(this.selectedObject)) {
+				this.selectedObject.setOpen(Boolean(value));
+			}
 		} else {
-			this.selectedObject.scale[axis] = value;
+			this.setNestedAttribute(this.selectedObject, attribute, value);
 		}
 
 		this.dispatchUpdated();
 		this.requestUpdate();
 	}
 
-	private handleRotationChange(axis: "x" | "y" | "z", event: Event) {
-		if (!this.selectedObject || this.isLocked()) return;
+	private getBaseFields(locked: boolean): DynamicFormField[] {
+		if (!this.selectedObject) return [];
 
-		const value = parseFloat((event.target as HTMLInputElement).value);
-		if (Number.isNaN(value)) return;
+		const fields: DynamicFormField[] = [
+			{
+				label: "Name",
+				attribute: "name",
+				type: "string",
+				tooltip: "Display name for the selected object.",
+				editable: !locked,
+				enabled: true,
+			},
+		];
 
-		this.selectedObject.rotation[axis] = (value * Math.PI) / 180;
-		this.dispatchUpdated();
-		this.requestUpdate();
-	}
-
-	private handleColorChange(event: Event) {
-		if (!this.hasEditableColor(this.selectedObject) || this.isLocked()) {
-			return;
+		if (this.selectedObject instanceof DTObject) {
+			fields.push({
+				label: "Locked",
+				attribute: "locked",
+				type: "boolean",
+				tooltip: "Prevent editing the object in the scene.",
+				editable: true,
+				enabled: true,
+			});
 		}
 
-		const value = (event.target as HTMLInputElement).value;
-		if (!/^#[0-9a-fA-F]{6}$/.test(value)) {
-			return;
+		fields.push(
+			{
+				label: "UUID",
+				attribute: "uuid",
+				type: "info",
+				tooltip: "Immutable identifier for the object instance.",
+				editable: false,
+				enabled: true,
+			},
+			{
+				label: "Position",
+				attribute: "position",
+				type: "Vector3",
+				tooltip: "Location of the object in meters.",
+				editable: !locked,
+				enabled: true,
+			},
+			{
+				label: "Scale",
+				attribute: "scale",
+				type: "Vector3",
+				tooltip: "Scale of the object along each axis.",
+				editable: !locked,
+				enabled: true,
+			},
+			{
+				label: "Rotation (degrees)",
+				attribute: "rotation",
+				type: "Vector3",
+				tooltip: "Rotation of the object in degrees.",
+				editable: !locked,
+				enabled: true,
+			},
+		);
+
+		if (this.hasEditableColor(this.selectedObject)) {
+			fields.push({
+				label: "Material Color",
+				attribute: "material.color",
+				type: "color",
+				tooltip: "Material base color.",
+				editable: !locked,
+				enabled: true,
+			});
 		}
 
-		this.selectedObject.material.color.set(value);
-		this.dispatchUpdated();
-		this.requestUpdate();
-	}
-
-	private handleLockChange(event: Event) {
-		if (!this.selectedObject || !(this.selectedObject instanceof DTObject)) {
-			return;
-		}
-
-		this.selectedObject.locked = (event.target as HTMLInputElement).checked;
-		this.dispatchUpdated();
-		this.requestUpdate();
-	}
-
-	private handleWallValueChange(
-		type: "height" | "thickness",
-		event: Event,
-	) {
-		if (!this.isWallObject(this.selectedObject) || this.isLocked()) {
-			return;
-		}
-
-		const value = parseFloat((event.target as HTMLInputElement).value);
-		if (Number.isNaN(value)) return;
-
-		if (type === "height") {
-			this.selectedObject.setHeight(value);
-		} else {
-			this.selectedObject.setThickness(value);
-		}
-
-		this.dispatchUpdated();
-		this.requestUpdate();
-	}
-
-	private handleOpenStateChange(event: Event) {
-		if (this.isLocked()) {
-			return;
-		}
-
-		const isOpen = (event.target as HTMLInputElement).checked;
-		if (this.isDoorObject(this.selectedObject)) {
-			this.selectedObject.setOpen(isOpen);
-		} else if (this.isWindowObject(this.selectedObject)) {
-			this.selectedObject.setOpen(isOpen);
-		} else {
-			return;
-		}
-
-		this.dispatchUpdated();
-		this.requestUpdate();
-	}
-
-	/**
-	 * Render a vector control element.
-	 *
-	 * @param label - Label of the element.
-	 * @param type - Type (position or scale)
-	 * @returns Rendered element.
-	 */
-	private renderVectorControls(
-		label: string,
-		type: "position" | "scale",
-		locked: boolean,
-	) {
-		if (!this.selectedObject) return null;
-
-		const source =
-			type === "position"
-				? this.selectedObject.position
-				: this.selectedObject.scale;
-
-		return html`
-			<div class="field">
-				<label>${label}</label>
-				<div class="group-row">
-					${(["x", "y", "z"] as const).map(
-						(axis) => html`
-							<label
-								>${axis.toUpperCase()}
-								<input
-									type="number"
-									step="0.01"
-									.value=${source[axis].toFixed(2)}
-									?disabled=${locked}
-									@change=${(event: Event) =>
-										this.handleVectorChange(type, axis, event)}
-								/>
-							</label>
-						`,
-					)}
-				</div>
-			</div>
-		`;
-	}
-
-	/**
-	 * Render euler rotation controls.
-	 *
-	 * @returns - Renderer element for rotation controls.
-	 */
-	private renderRotationControls(locked: boolean) {
-		if (!this.selectedObject) {
-			return null;
-		}
-
-		return html`
-			<div class="field">
-				<label>Rotation (degrees)</label>
-				<div class="group-row">
-					${(["x", "y", "z"] as const).map(
-						(axis) => html`
-							<label
-								>${axis.toUpperCase()}
-								<input
-									type="number"
-									step="1"
-									.value=${(
-										(this.selectedObject!.rotation[axis] * 180) /
-										Math.PI
-									).toFixed(1)}
-									?disabled=${locked}
-									@change=${(event: Event) =>
-										this.handleRotationChange(axis, event)}
-								/>
-							</label>
-						`,
-					)}
-				</div>
-			</div>
-		`;
-	}
-
-	private renderMaterialControls(locked: boolean) {
-		if (!this.hasEditableColor(this.selectedObject)) {
-			return null;
-		}
-
-		const color = this.selectedObject.material.color;
-
-		return html`
-			<div class="field color-field">
-				<label>Material Color</label>
-				<input
-					type="color"
-					class="color-input"
-					.value=${`#${color.getHexString()}`}
-					?disabled=${locked}
-					@input=${(event: Event) => this.handleColorChange(event)}
-				/>
-			</div>
-		`;
+		return fields;
 	}
 
 	private renderEntityDetails() {
-		// Check if object is entity
 		if (!this.isEntityObject(this.selectedObject)) {
 			return null;
 		}
 
 		const entityData = this.selectedObject.getEntity();
-		const friendlyName =
-			entityData?.attributes?.friendly_name ?? this.selectedObject.entityId;
-		const stateValue = entityData?.state ?? "unknown";
 		const attributes = entityData?.attributes ?? {};
 		const attributeEntries = Object.entries(attributes);
 
 		return html`
-			<h4>Entity</h4>
-			<div class="field">
-				<label>Entity ID</label>
-				<input type="text" .value=${this.selectedObject.entityId} readonly />
-			</div>
-			<div class="field">
-				<label>Entity Name</label>
-				<input type="text" .value=${friendlyName} readonly />
-			</div>
-			<div class="field">
-				<label>State</label>
-				<input type="text" .value=${String(stateValue)} readonly />
-			</div>
 			<div class="field">
 				<label>Attributes</label>
 				${attributeEntries.length
@@ -329,107 +243,155 @@ export class DT3DObjectInspector extends LitElement {
 		`;
 	}
 
-	private renderWallControls(locked: boolean) {
+	private getWallFields(locked: boolean): DynamicFormField[] {
 		if (!this.isWallObject(this.selectedObject)) {
-			return null;
+			return [];
 		}
 
-		return html`
-			<h4>Wall</h4>
-			<div class="field">
-				<label>Height (m)</label>
-				<input
-					type="number"
-					step="0.1"
-					min="0.1"
-					.value=${this.selectedObject.height.toFixed(2)}
-					?disabled=${locked}
-					@change=${(event: Event) => this.handleWallValueChange("height", event)}
-				/>
-			</div>
-			<div class="field">
-				<label>Thickness (m)</label>
-				<input
-					type="number"
-					step="0.05"
-					min="0.05"
-					.value=${this.selectedObject.thickness.toFixed(2)}
-					?disabled=${locked}
-					@change=${(event: Event) =>
-						this.handleWallValueChange("thickness", event)}
-				/>
-			</div>
-		`;
+		return [
+			{
+				label: "Height (m)",
+				attribute: "height",
+				type: "number",
+				tooltip: "Wall height in meters.",
+				editable: !locked,
+				enabled: true,
+			},
+			{
+				label: "Thickness (m)",
+				attribute: "thickness",
+				type: "number",
+				tooltip: "Wall thickness in meters.",
+				editable: !locked,
+				enabled: true,
+			},
+		];
 	}
 
-	private renderOpeningControls(locked: boolean) {
+	private getOpeningFields(locked: boolean): DynamicFormField[] {
 		if (!this.isDoorObject(this.selectedObject) && !this.isWindowObject(this.selectedObject)) {
+			return [];
+		}
+
+		return [
+			{
+				label: "Open",
+				attribute: "open",
+				type: "boolean",
+				tooltip: "Toggle the open state.",
+				editable: !locked,
+				enabled: true,
+			},
+		];
+	}
+
+	private getEntityFields(): DynamicFormField[] {
+		if (!this.isEntityObject(this.selectedObject)) {
+			return [];
+		}
+
+		return [
+			{
+				label: "Entity ID",
+				attribute: "entityId",
+				type: "info",
+				editable: false,
+				enabled: true,
+			},
+			{
+				label: "Entity Name",
+				attribute: "entityName",
+				type: "info",
+				editable: false,
+				enabled: true,
+			},
+			{
+				label: "State",
+				attribute: "entityState",
+				type: "info",
+				editable: false,
+				enabled: true,
+			},
+		];
+	}
+
+	private getEntityData(): Record<string, unknown> | null {
+		if (!this.isEntityObject(this.selectedObject)) {
 			return null;
 		}
 
-		const isOpen = this.selectedObject?.open ?? false;
-		const label = this.isDoorObject(this.selectedObject) ? "Door" : "Window";
+		const entityData = this.selectedObject.getEntity();
+		const friendlyName =
+			entityData?.attributes?.friendly_name ?? this.selectedObject.entityId;
+		const stateValue = entityData?.state ?? "unknown";
 
-		return html`
-			<h4>${label}</h4>
-			<div class="field">
-				<label>
-					<input
-						type="checkbox"
-						.checked=${isOpen}
-						?disabled=${locked}
-						@change=${(event: Event) => this.handleOpenStateChange(event)}
-					/>
-					Open
-				</label>
-			</div>
-		`;
+		return {
+			entityId: this.selectedObject.entityId,
+			entityName: friendlyName,
+			entityState: String(stateValue),
+		};
 	}
 
 	public render() {
 		const locked = this.isLocked();
-		const isDTObject = this.selectedObject instanceof DTObject;
+		const baseFields = this.getBaseFields(locked);
+		const wallFields = this.getWallFields(locked);
+		const openingFields = this.getOpeningFields(locked);
+		const entityFields = this.getEntityFields();
+		const entityData = this.getEntityData();
 
 		return html`
 			<h4>Selected Object</h4>
 			${this.selectedObject
 				? html`
-						<div class="field">
-							<label>Name</label>
-							<input
-								type="text"
-								.value=${this.selectedObject.name || ""}
-								?disabled=${locked}
-								@input=${(event: Event) => this.handleNameChange(event)}
-							/>
-						</div>
-						${isDTObject
-							? html`<div class="field">
-									<label>
-										<input
-											type="checkbox"
-											.checked=${locked}
-											@change=${(event: Event) => this.handleLockChange(event)}
-										/>
-										Locked
-									</label>
-								</div>`
-							: null}
-						<div class="field">
-							<label>UUID</label>
-							<input type="text" .value=${this.selectedObject.uuid} readonly />
-						</div>
+						<dynamic-form
+							.fields=${baseFields}
+							.data=${this.selectedObject}
+							@field-change=${(event: CustomEvent<DynamicFormChangeDetail>) =>
+								this.handleFormFieldChange(event)}
+						></dynamic-form>
 						${locked
 							? html`<div class="placeholder">
 									This object is locked and cannot be edited.
 								</div>`
 							: null}
-						${this.renderVectorControls("Position", "position", locked)}
-						${this.renderVectorControls("Scale", "scale", locked)}
-						${this.renderRotationControls(locked)}
-						${this.renderMaterialControls(locked)}
-						${this.renderWallControls(locked)}
-						${this.renderOpeningControls(locked)}
+						${wallFields.length
+							? html`
+									<h4>Wall</h4>
+									<dynamic-form
+										.fields=${wallFields}
+										.data=${this.selectedObject}
+										@field-change=${(
+											event: CustomEvent<DynamicFormChangeDetail>,
+										) => this.handleFormFieldChange(event)}
+									></dynamic-form>
+								`
+							: null}
+						${openingFields.length
+							? html`
+									<h4>
+										${this.isDoorObject(this.selectedObject)
+											? "Door"
+											: "Window"}
+									</h4>
+									<dynamic-form
+										.fields=${openingFields}
+										.data=${this.selectedObject}
+										@field-change=${(
+											event: CustomEvent<DynamicFormChangeDetail>,
+										) => this.handleFormFieldChange(event)}
+									></dynamic-form>
+								`
+							: null}
+						${entityFields.length
+							? html`
+									<h4>Entity</h4>
+									<dynamic-form
+										.fields=${entityFields}
+										.data=${entityData}
+									></dynamic-form>
+								`
+							: null}
 						${this.renderEntityDetails()}
 					`
 				: html`<div class="placeholder">


### PR DESCRIPTION
### Motivation
- Provide a reusable dynamic form renderer so inspector fields can be declared via configuration and reused across object types.
- Reduce duplicated field rendering logic in the object inspector by moving controls to a single configurable component.
- Support common field types (vectors, strings, numbers, booleans, colors, info) and nested attributes for flexible object editing.

### Description
- Add `dynamic-form` web component (`frontend/src/components/dynamic-form.ts`) and styles (`frontend/src/components/dynamic-form.css`) that accept a `fields` configuration array and `data` object and emit `field-change` events when values change.
- Implement support in the form for `Vector3`, `string`, `number`, `boolean`, `color`, and `info` field types and handle nested attribute access (dot-paths) and Euler/degree display for vectors.
- Refactor the object inspector (`frontend/src/components/object-tree/object-inspector.ts`) to build field lists per object type (`getBaseFields`, `getWallFields`, `getOpeningFields`, `getEntityFields`) and render `dynamic-form` instances, plus a `handleFormFieldChange` handler that applies updates to the selected object (including rotation conversion, material color, wall dimensions, open state and nested attributes).
- Keep entity attributes list rendering, but expose entity ID/name/state as read-only info fields via the dynamic form when available.

### Testing
- Ran `npm install` in `frontend` which completed successfully with no vulnerabilities reported.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready and served the app locally (`http://localhost:4173/`).
- Attempted automated screenshot verification via Playwright but Chromium crashed on launch and Firefox returned an empty response, so UI screenshot capture failed. No further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976409e6fe88332a697bd309e84263d)