### PR TITLE
Add DRACOLoader support for GLTF/GLB imports

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -11,6 +11,7 @@ import {
 import type { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import type { TransformControls } from "three/examples/jsm/controls/TransformControls";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
+import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader.js";
 import { OBJLoader } from "three/examples/jsm/loaders/OBJLoader.js";
 import { FBXLoader } from "three/examples/jsm/loaders/FBXLoader.js";
 import { LitElement } from "lit";
@@ -212,14 +213,21 @@ export class DT3DCard extends LitElement {
 
 		if (extension === "gltf" || extension === "glb") {
 			const loader = new GLTFLoader();
+			const dracoLoader = new DRACOLoader();
+			dracoLoader.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/");
+			loader.setDRACOLoader(dracoLoader);
 			loader.load(
 				url,
 				(gltf: any) => {
+					dracoLoader.dispose();
 					cleanup();
 					this.addToScene(gltf.scene ?? gltf.scenes?.[0], file.name);
 				},
 				undefined,
-				onError,
+				(error: any) => {
+					onError(error);
+					dracoLoader.dispose();
+				},
 			);
 			return;
 		} else if (extension === "obj") {


### PR DESCRIPTION
### Motivation
- GLTF/GLB uploads failed for compressed models with `THREE.GLTFLoader: No DRACOLoader instance provided`, so the loader needs to be wired up to decode Draco-compressed meshes.

### Description
- Import `DRACOLoader` and instantiate it when loading `.gltf`/`.glb` files in `frontend/src/components/card.ts`.
- Configure the decoder path via `dracoLoader.setDecoderPath("https://www.gstatic.com/draco/v1/decoders/")` and attach it to the `GLTFLoader` with `loader.setDRACOLoader(dracoLoader)`.
- Dispose the `dracoLoader` after successful load and on error to avoid leaking resources, while preserving the existing URL cleanup logic.
- Changes are localized to the GLTF/GLB branch of `loadModelFromFile` and add the `DRACOLoader` import.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ddaec98b08332a976bcc9a5f4d27a)