### PR TITLE
Fix object tree child indentation by depth

### DIFF
--- a/frontend/src/components/object-tree/object-tree.css
+++ b/frontend/src/components/object-tree/object-tree.css
@@ -17,7 +17,7 @@
 }
 
 .tree-node {
-	padding-left: 16px;
+	padding-left: calc(8px + (var(--tree-depth, 0) * 16px));
 	cursor: pointer;
 	user-select: none;
 	text-overflow: ellipsis;

--- a/frontend/src/components/object-tree/object-tree.ts
+++ b/frontend/src/components/object-tree/object-tree.ts
@@ -420,6 +420,7 @@ export class DT3DTree extends LitElement {
 							<!-- Node -->
 							<div
 								class="tree-node ${this.selectedId === node.id ? "selected" : ""}"
+								style=${`--tree-depth: ${depth};`}
 								@click=${() => this.selectObject(node.id, true)}
 								@contextmenu=${(event: MouseEvent) =>
 									this.handleContextMenu(event, node.id)}


### PR DESCRIPTION
### Motivation
- Nested nodes in the object tree were rendered at the same horizontal position, making hierarchy indistinguishable; the change introduces per-level visual offset so children are indented by depth.

### Description
- Pass the current recursion `depth` into each rendered node as a CSS custom property by adding `style=${`--tree-depth: ${depth};`}` to the node container in `renderTree` in `frontend/src/components/object-tree/object-tree.ts`.
- Compute the left padding for `.tree-node` from `--tree-depth` by changing `padding-left` to `calc(8px + (var(--tree-depth, 0) * 16px))` in `frontend/src/components/object-tree/object-tree.css` so indentation scales per-level.
- Keep existing toggle and selection behavior unchanged while only adjusting layout responsibility to CSS.

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully.
- Launched the dev server and captured a screenshot via an automated Playwright script to validate the visual indentation, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69919eb8d3748332b7a816e34f7d093f)