### PR TITLE
Fix wall endpoint span and door/window opening alignment

### DIFF
--- a/frontend/src/objects/house/wall.ts
+++ b/frontend/src/objects/house/wall.ts
@@ -101,12 +101,15 @@ export class WallObject extends DTObject {
 	 * @param end - Ending point
 	 */
 	public setFromPoints(start: Vector3, end: Vector3): void {
-		const length = start.distanceTo(end);
+		const direction = end.clone().sub(start);
+		const length = Math.hypot(direction.x, direction.z);
+		if (length <= 0) {
+			return;
+		}
 
 		const midpoint = start.clone().add(end).multiplyScalar(0.5);
 		this.position.set(midpoint.x, start.y, midpoint.z);
 
-		const direction = end.clone().sub(start);
 		const angle = Math.atan2(direction.z, direction.x);
 		this.rotation.set(0, angle, 0);
 
@@ -166,7 +169,7 @@ export class WallObject extends DTObject {
 		this.doorCount += 1;
 		const door = new DoorObject();
 		door.name = `Door ${this.doorCount}`;
-		door.position.y = door.height / 2;
+		door.position.y = 0;
 		this.add(door);
 		this.updateGeometry();
 		return door;
@@ -179,7 +182,7 @@ export class WallObject extends DTObject {
 		this.windowCount += 1;
 		const window = new WindowObject();
 		window.name = `Window ${this.windowCount}`;
-		window.position.y = 1.2 + window.height / 2;
+		window.position.y = 1.2;
 		this.add(window);
 		this.updateGeometry();
 		return window;
@@ -278,7 +281,7 @@ export class WallObject extends DTObject {
 					width: child.width,
 					height: child.height,
 					x: child.position.x,
-					y: child.position.y,
+					y: child.position.y + child.height / 2,
 				});
 			}
 			if (child instanceof WindowObject) {
@@ -286,7 +289,7 @@ export class WallObject extends DTObject {
 					width: child.width,
 					height: child.height,
 					x: child.position.x,
-					y: child.position.y,
+					y: child.position.y + child.height / 2,
 				});
 			}
 		}


### PR DESCRIPTION
### Motivation

- Wall placement and openings were misaligned because wall length used full 3D distance and door/window hole positions did not match rendered meshes.

### Description

- Compute wall length in `setFromPoints` using horizontal XZ span (`Math.hypot(direction.x, direction.z)`) and guard against zero-length updates to keep walls aligned to floor click points.
- Treat door/window `position.y` as the opening base by default (`door.position.y = 0`, `window.position.y = 1.2`) so placements reflect intended floor/sill heights.
- Convert opening base to center when creating cutouts (`y: child.position.y + child.height / 2`) so the carved holes line up vertically with the door/window meshes.
- Changes made in `frontend/src/objects/house/wall.ts` affecting `setFromPoints`, `addDoor`, `addWindow`, and `getOpenings`/shape hole generation.

### Testing

- Ran `cd frontend && npm install`, which completed successfully with no vulnerabilities found.
- Ran `cd frontend && npm run build`, which completed successfully and produced the distribution bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a04b58348332a730b3dfbcdebe7d)