### PR TITLE
Add editable mesh geometry parameters

### DIFF
--- a/frontend/src/components/dynamic-form/dynamic-form.ts
+++ b/frontend/src/components/dynamic-form/dynamic-form.ts
@@ -24,6 +24,8 @@ export type DynamicFormField = {
 	tooltip?: string;
 	editable: boolean;
 	enabled: boolean;
+	step?: number;
+	min?: number;
 };
 
 /**
@@ -245,13 +247,15 @@ export class DynamicForm extends LitElement {
 			}
 			case "number": {
 				const value = Number(this.getFieldValue(field) ?? 0);
+				const step = field.step ?? 0.01;
 				return html`
 					<div class="field">
 						<label title=${field.tooltip ?? ""}>${field.label}</label>
 						<input
 							type="number"
-							step="0.01"
-							.value=${this.formatNumber(value)}
+							step=${String(step)}
+							min=${field.min == null ? undefined : String(field.min)}
+							.value=${this.formatNumber(value, step >= 1 ? 0 : 2)}
 							?disabled=${!field.editable}
 							@change=${(event: Event) => {
 								const rawValue = parseFloat(

--- a/frontend/src/components/object-inspector/object-inspector.ts
+++ b/frontend/src/components/object-inspector/object-inspector.ts
@@ -3,8 +3,9 @@ import "../dynamic-form/dynamic-form.js";
 import {html, LitElement, unsafeCSS} from "lit";
 import {customElement, property} from "lit/decorators.js";
 import type {Object3D} from "three";
-import {Color} from "three";
+import {Color, Mesh} from "three";
 
+import {getMeshGeometryParameters, MESH_GEOMETRY_PARAMETER_DEFINITIONS, resolveMeshType, updateMeshGeometry} from "../../editor/mesh-handler.js";
 import {localManager} from "../../locale/locale.js";
 import {DTObject} from "../../objects/dt-object.js";
 import {EntityObject} from "../../objects/entity-object.js";
@@ -127,6 +128,19 @@ export class DT3DObjectInspector extends LitElement {
 				this.selectedObject.setHeight(rawValue);
 			} else {
 				this.selectedObject.setThickness(rawValue);
+			}
+		} else if (attribute.startsWith("geometry.")) {
+			if (!(this.selectedObject instanceof Mesh)) {
+				return;
+			}
+			const geometryParameters = getMeshGeometryParameters(this.selectedObject);
+			if (!geometryParameters) {
+				return;
+			}
+			const parameterName = attribute.slice("geometry.".length);
+			geometryParameters[parameterName] = value as number | boolean;
+			if (!updateMeshGeometry(this.selectedObject, geometryParameters)) {
+				return;
 			}
 		} else if (attribute === "open") {
 			if (this.isDoorObject(this.selectedObject)) {
@@ -289,6 +303,36 @@ export class DT3DObjectInspector extends LitElement {
 		];
 	}
 
+	private getGeometryFields(locked: boolean): DynamicFormField[] {
+		if (!this.selectedObject || !(this.selectedObject instanceof Mesh)) {
+			return [];
+		}
+
+		const meshType = resolveMeshType(this.selectedObject);
+		if (!meshType) {
+			return [];
+		}
+
+		const geometryParameters = getMeshGeometryParameters(this.selectedObject);
+		const definitions = MESH_GEOMETRY_PARAMETER_DEFINITIONS[meshType] ?? [];
+		if (!geometryParameters || definitions.length === 0) {
+			return [];
+		}
+
+		this.selectedObject.userData.geometryParameters = geometryParameters;
+
+		return definitions.map((definition) => ({
+			label: definition.label,
+			attribute: `geometry.${definition.name}`,
+			type: definition.type === "boolean" ? "boolean" : "number",
+			tooltip: localManager.get("geometryParameterTooltip"),
+			editable: !locked,
+			enabled: true,
+			step: definition.step,
+			min: definition.min,
+		}));
+	}
+
 	private getEntityFields(): DynamicFormField[] {
 		if (!this.isEntityObject(this.selectedObject)) {
 			return [];
@@ -341,6 +385,8 @@ export class DT3DObjectInspector extends LitElement {
 		const baseFields = this.getBaseFields(locked);
 		const wallFields = this.getWallFields(locked);
 		const openingFields = this.getOpeningFields(locked);
+		const geometryFields = this.getGeometryFields(locked);
+		const geometryData = this.selectedObject instanceof Mesh ? this.selectedObject.userData : null;
 		const entityFields = this.getEntityFields();
 		const entityData = this.getEntityData();
 
@@ -381,6 +427,18 @@ export class DT3DObjectInspector extends LitElement {
 									<dt3d-dynamic-form
 										.fields=${openingFields}
 										.data=${this.selectedObject}
+										@field-change=${(
+		event: CustomEvent<DynamicFormChangeDetail>,
+	) => this.handleFormFieldChange(event)}
+									></dt3d-dynamic-form>
+								`
+		: null}
+						${geometryFields.length
+		? html`
+									<h4>${localManager.get("geometry")}</h4>
+									<dt3d-dynamic-form
+										.fields=${geometryFields}
+										.data=${geometryData}
 										@field-change=${(
 		event: CustomEvent<DynamicFormChangeDetail>,
 	) => this.handleFormFieldChange(event)}

--- a/frontend/src/editor/mesh-handler.ts
+++ b/frontend/src/editor/mesh-handler.ts
@@ -1,10 +1,23 @@
-import type {Material, Object3D} from "three";
+import type {BufferGeometry, Material, Object3D} from "three";
 import {BoxGeometry, CapsuleGeometry, CircleGeometry, ConeGeometry, CylinderGeometry, DodecahedronGeometry, IcosahedronGeometry, Mesh, OctahedronGeometry, PlaneGeometry, RingGeometry, SphereGeometry, TetrahedronGeometry, TorusGeometry, TorusKnotGeometry} from "three";
 
 export type MeshOption = {
 	type: string;
 	label: string;
 };
+
+export type MeshGeometryParameterType = "number" | "integer" | "boolean";
+
+export type MeshGeometryParameterDefinition = {
+	name: string;
+	label: string;
+	type: MeshGeometryParameterType;
+	defaultValue: number | boolean;
+	min?: number;
+	step?: number;
+};
+
+export type MeshGeometryParameters = Record<string, number | boolean>;
 
 /**
  * List of possible mesh options to present on the GUI.
@@ -26,12 +39,94 @@ export const MESH_OPTIONS: MeshOption[] = [
 	{type: "torusKnot", label: "Torus Knot"},
 ];
 
+const TWO_PI = Math.PI * 2;
+const int = (name: string, label: string, defaultValue: number, min = 1): MeshGeometryParameterDefinition => ({name, label, type: "integer", defaultValue, min, step: 1});
+const num = (name: string, label: string, defaultValue: number, min = 0, step = 0.01): MeshGeometryParameterDefinition => ({name, label, type: "number", defaultValue, min, step});
+const bool = (name: string, label: string, defaultValue: boolean): MeshGeometryParameterDefinition => ({name, label, type: "boolean", defaultValue});
+
+/**
+ * Constructor parameters supported by each built-in three.js geometry exposed by the mesh menu.
+ */
+export const MESH_GEOMETRY_PARAMETER_DEFINITIONS: Record<string, MeshGeometryParameterDefinition[]> = {
+	cube: [num("width", "Width", 1), num("height", "Height", 1), num("depth", "Depth", 1), int("widthSegments", "Width Segments", 1), int("heightSegments", "Height Segments", 1), int("depthSegments", "Depth Segments", 1)],
+	sphere: [num("radius", "Radius", 0.6), int("widthSegments", "Width Segments", 32, 3), int("heightSegments", "Height Segments", 16, 2), num("phiStart", "Phi Start", 0), num("phiLength", "Phi Length", TWO_PI), num("thetaStart", "Theta Start", 0), num("thetaLength", "Theta Length", Math.PI)],
+	plane: [num("width", "Width", 1), num("height", "Height", 1), int("widthSegments", "Width Segments", 1), int("heightSegments", "Height Segments", 1)],
+	capsule: [num("radius", "Radius", 0.4), num("length", "Length", 1), int("capSegments", "Cap Segments", 6), int("radialSegments", "Radial Segments", 12, 3)],
+	circle: [num("radius", "Radius", 0.6), int("segments", "Segments", 32, 3), num("thetaStart", "Theta Start", 0), num("thetaLength", "Theta Length", TWO_PI)],
+	cone: [num("radius", "Radius", 0.5), num("height", "Height", 1), int("radialSegments", "Radial Segments", 32, 3), int("heightSegments", "Height Segments", 1), bool("openEnded", "Open Ended", false), num("thetaStart", "Theta Start", 0), num("thetaLength", "Theta Length", TWO_PI)],
+	cylinder: [num("radiusTop", "Top Radius", 0.4), num("radiusBottom", "Bottom Radius", 0.4), num("height", "Height", 1), int("radialSegments", "Radial Segments", 32, 3), int("heightSegments", "Height Segments", 1), bool("openEnded", "Open Ended", false), num("thetaStart", "Theta Start", 0), num("thetaLength", "Theta Length", TWO_PI)],
+	dodecahedron: [num("radius", "Radius", 0.6), int("detail", "Detail", 0, 0)],
+	icosahedron: [num("radius", "Radius", 0.6), int("detail", "Detail", 0, 0)],
+	octahedron: [num("radius", "Radius", 0.6), int("detail", "Detail", 0, 0)],
+	ring: [num("innerRadius", "Inner Radius", 0.3), num("outerRadius", "Outer Radius", 0.6), int("thetaSegments", "Theta Segments", 32, 3), int("phiSegments", "Phi Segments", 1), num("thetaStart", "Theta Start", 0), num("thetaLength", "Theta Length", TWO_PI)],
+	tetrahedron: [num("radius", "Radius", 0.6), int("detail", "Detail", 0, 0)],
+	torus: [num("radius", "Radius", 0.5), num("tube", "Tube", 0.2), int("radialSegments", "Radial Segments", 16, 3), int("tubularSegments", "Tubular Segments", 60, 3), num("arc", "Arc", TWO_PI)],
+	torusKnot: [num("radius", "Radius", 0.4), num("tube", "Tube", 0.15), int("tubularSegments", "Tubular Segments", 80, 3), int("radialSegments", "Radial Segments", 12, 3), int("p", "P", 2, 1), int("q", "Q", 3, 1)],
+};
+
+function normalizeGeometryParameters(type: string, parameters: MeshGeometryParameters = {}): MeshGeometryParameters {
+	const definitions = MESH_GEOMETRY_PARAMETER_DEFINITIONS[type] ?? [];
+	return Object.fromEntries(definitions.map((definition) => {
+		const value = parameters[definition.name] ?? definition.defaultValue;
+		if (definition.type === "boolean") {
+			return [definition.name, Boolean(value)];
+		}
+		const numericValue = Number(value);
+		const fallback = Number(definition.defaultValue);
+		const normalized = Number.isFinite(numericValue) ? numericValue : fallback;
+		const clamped = definition.min == null ? normalized : Math.max(definition.min, normalized);
+		return [definition.name, definition.type === "integer" ? Math.round(clamped) : clamped];
+	}));
+}
+
+export function getMeshGeometryParameters(object: Object3D): MeshGeometryParameters | null {
+	const meshType = resolveMeshType(object);
+	if (!meshType || !(object instanceof Mesh)) {
+		return null;
+	}
+
+	return normalizeGeometryParameters(meshType, object.userData.geometryParameters ?? object.geometry?.parameters ?? {});
+}
+
+function createGeometry(type: string, parameters: MeshGeometryParameters): BufferGeometry | null {
+	const params = normalizeGeometryParameters(type, parameters) as any;
+	switch (type) {
+		case "cube": return new BoxGeometry(params.width, params.height, params.depth, params.widthSegments, params.heightSegments, params.depthSegments);
+		case "sphere": return new SphereGeometry(params.radius, params.widthSegments, params.heightSegments, params.phiStart, params.phiLength, params.thetaStart, params.thetaLength);
+		case "plane": return new PlaneGeometry(params.width, params.height, params.widthSegments, params.heightSegments);
+		case "capsule": return new CapsuleGeometry(params.radius, params.length, params.capSegments, params.radialSegments);
+		case "circle": return new CircleGeometry(params.radius, params.segments, params.thetaStart, params.thetaLength);
+		case "cone": return new ConeGeometry(params.radius, params.height, params.radialSegments, params.heightSegments, params.openEnded, params.thetaStart, params.thetaLength);
+		case "cylinder": return new CylinderGeometry(params.radiusTop, params.radiusBottom, params.height, params.radialSegments, params.heightSegments, params.openEnded, params.thetaStart, params.thetaLength);
+		case "dodecahedron": return new DodecahedronGeometry(params.radius, params.detail);
+		case "icosahedron": return new IcosahedronGeometry(params.radius, params.detail);
+		case "octahedron": return new OctahedronGeometry(params.radius, params.detail);
+		case "ring": return new RingGeometry(params.innerRadius, params.outerRadius, params.thetaSegments, params.phiSegments, params.thetaStart, params.thetaLength);
+		case "tetrahedron": return new TetrahedronGeometry(params.radius, params.detail);
+		case "torus": return new TorusGeometry(params.radius, params.tube, params.radialSegments, params.tubularSegments, params.arc);
+		case "torusKnot": return new TorusKnotGeometry(params.radius, params.tube, params.tubularSegments, params.radialSegments, params.p, params.q);
+		default: return null;
+	}
+}
+
+export function updateMeshGeometry(object: Object3D, parameters: MeshGeometryParameters): boolean {
+	const meshType = resolveMeshType(object);
+	if (!meshType || !(object instanceof Mesh)) {
+		return false;
+	}
+	const normalizedParameters = normalizeGeometryParameters(meshType, parameters);
+	const geometry = createGeometry(meshType, normalizedParameters);
+	if (!geometry) {
+		return false;
+	}
+	object.geometry.dispose();
+	object.geometry = geometry;
+	object.userData.geometryParameters = normalizedParameters;
+	return true;
+}
 
 /**
  * Resolve the mesh type of an object based on its geometry or user data.
- * 
- * @param object - The object to resolve the mesh type for.
- * @returns The resolved mesh type, or null if it cannot be determined.
  */
 export function resolveMeshType(object: Object3D): string | null {
 	const meshType = object.userData.meshType as string | undefined;
@@ -93,89 +188,32 @@ export function resolveMeshType(object: Object3D): string | null {
 
 /**
  * Create a mesh object of the specified type with the given material.
- * 
- * @param type - The type of mesh to create (e.g. "cube", "sphere", etc.). 
- * @param material - The material to apply to the mesh.
- * @returns Mesh object of the specified type, or null if the type is not recognized.
  */
-export function createMeshObject(type: string, material: Material): Mesh {
+export function createMeshObject(type: string, material: Material, parameters: MeshGeometryParameters = {}): Mesh {
+	const geometry = createGeometry(type, parameters);
 	let object: Mesh = null;
 
+	if (geometry) {
+		object = new Mesh(geometry, material);
+		object.userData.geometryParameters = normalizeGeometryParameters(type, parameters);
+	}
+
 	switch (type) {
-		case "cube": {
-			object = new Mesh(new BoxGeometry(), material);
-			object.name = "Cube";
-			break;
-		}
-		case "sphere": {
-			object = new Mesh(new SphereGeometry(0.6, 32, 16), material);
-			object.name = "Sphere";
-			break;
-		}
-		case "plane": {
-			object = new Mesh(new PlaneGeometry(1, 1, 1), material);
-			object.rotation.x = -Math.PI / 2;
-			object.position.y = -1;
-			object.name = "Plane";
-			break;
-		}
-		case "capsule": {
-			object = new Mesh(new CapsuleGeometry(0.4, 1, 6, 12), material);
-			object.name = "Capsule";
-			break;
-		}
-		case "circle": {
-			object = new Mesh(new CircleGeometry(0.6, 32), material);
-			object.name = "Circle";
-			break;
-		}
-		case "cone": {
-			object = new Mesh(new ConeGeometry(0.5, 1, 32), material);
-			object.name = "Cone";
-			break;
-		}
-		case "cylinder": {
-			object = new Mesh(new CylinderGeometry(0.4, 0.4, 1, 32), material);
-			object.name = "Cylinder";
-			break;
-		}
-		case "dodecahedron": {
-			object = new Mesh(new DodecahedronGeometry(0.6), material);
-			object.name = "Dodecahedron";
-			break;
-		}
-		case "icosahedron": {
-			object = new Mesh(new IcosahedronGeometry(0.6), material);
-			object.name = "Icosahedron";
-			break;
-		}
-		case "octahedron": {
-			object = new Mesh(new OctahedronGeometry(0.6), material);
-			object.name = "Octahedron";
-			break;
-		}
-		case "ring": {
-			object = new Mesh(new RingGeometry(0.3, 0.6, 32), material);
-			object.name = "Ring";
-			break;
-		}
-		case "tetrahedron": {
-			object = new Mesh(new TetrahedronGeometry(0.6), material);
-			object.name = "Tetrahedron";
-			break;
-		}
-		case "torus": {
-			object = new Mesh(new TorusGeometry(0.5, 0.2, 16, 60), material);
-			object.name = "Torus";
-			break;
-		}
-		case "torusKnot": {
-			object = new Mesh(new TorusKnotGeometry(0.4, 0.15, 80, 12), material);
-			object.name = "Torus Knot";
-			break;
-		}
-		default:
-			break;
+		case "cube": object.name = "Cube"; break;
+		case "sphere": object.name = "Sphere"; break;
+		case "plane": object.rotation.x = -Math.PI / 2; object.position.y = -1; object.name = "Plane"; break;
+		case "capsule": object.name = "Capsule"; break;
+		case "circle": object.name = "Circle"; break;
+		case "cone": object.name = "Cone"; break;
+		case "cylinder": object.name = "Cylinder"; break;
+		case "dodecahedron": object.name = "Dodecahedron"; break;
+		case "icosahedron": object.name = "Icosahedron"; break;
+		case "octahedron": object.name = "Octahedron"; break;
+		case "ring": object.name = "Ring"; break;
+		case "tetrahedron": object.name = "Tetrahedron"; break;
+		case "torus": object.name = "Torus"; break;
+		case "torusKnot": object.name = "Torus Knot"; break;
+		default: break;
 	}
 
 	return object;

--- a/frontend/src/editor/mesh-handler.ts
+++ b/frontend/src/editor/mesh-handler.ts
@@ -1,22 +1,42 @@
 import type {BufferGeometry, Material, Object3D} from "three";
 import {BoxGeometry, CapsuleGeometry, CircleGeometry, ConeGeometry, CylinderGeometry, DodecahedronGeometry, IcosahedronGeometry, Mesh, OctahedronGeometry, PlaneGeometry, RingGeometry, SphereGeometry, TetrahedronGeometry, TorusGeometry, TorusKnotGeometry} from "three";
 
+/**
+ * Mesh type option rendered by the add-mesh menu.
+ */
 export type MeshOption = {
+	/** Stable mesh type identifier used by persistence and factory helpers. */
 	type: string;
+	/** Human-readable label displayed in the mesh menu. */
 	label: string;
 };
 
+/**
+ * Supported inspector control types for a geometry constructor parameter.
+ */
 export type MeshGeometryParameterType = "number" | "integer" | "boolean";
 
+/**
+ * Metadata describing one editable three.js geometry constructor parameter.
+ */
 export type MeshGeometryParameterDefinition = {
+	/** Constructor parameter name, matching the key stored by three.js geometry parameters. */
 	name: string;
+	/** Human-readable label displayed in the object inspector. */
 	label: string;
+	/** Form control type used to edit this parameter. */
 	type: MeshGeometryParameterType;
+	/** Default value used when a mesh or persisted payload omits this parameter. */
 	defaultValue: number | boolean;
+	/** Optional minimum numeric value accepted by the inspector and normalizer. */
 	min?: number;
+	/** Optional numeric input step used by the inspector. */
 	step?: number;
 };
 
+/**
+ * Current geometry constructor parameter values for a mesh.
+ */
 export type MeshGeometryParameters = Record<string, number | boolean>;
 
 /**
@@ -40,8 +60,38 @@ export const MESH_OPTIONS: MeshOption[] = [
 ];
 
 const TWO_PI = Math.PI * 2;
+
+/**
+ * Create metadata for an integer geometry constructor parameter.
+ *
+ * @param name - Constructor parameter name.
+ * @param label - Human-readable inspector label.
+ * @param defaultValue - Fallback value used when the parameter is missing.
+ * @param min - Minimum accepted value.
+ * @returns Geometry parameter metadata configured with integer stepping.
+ */
 const int = (name: string, label: string, defaultValue: number, min = 1): MeshGeometryParameterDefinition => ({name, label, type: "integer", defaultValue, min, step: 1});
+
+/**
+ * Create metadata for a decimal geometry constructor parameter.
+ *
+ * @param name - Constructor parameter name.
+ * @param label - Human-readable inspector label.
+ * @param defaultValue - Fallback value used when the parameter is missing.
+ * @param min - Minimum accepted value.
+ * @param step - Numeric input step shown by the inspector.
+ * @returns Geometry parameter metadata configured for decimal input.
+ */
 const num = (name: string, label: string, defaultValue: number, min = 0, step = 0.01): MeshGeometryParameterDefinition => ({name, label, type: "number", defaultValue, min, step});
+
+/**
+ * Create metadata for a boolean geometry constructor parameter.
+ *
+ * @param name - Constructor parameter name.
+ * @param label - Human-readable inspector label.
+ * @param defaultValue - Fallback value used when the parameter is missing.
+ * @returns Geometry parameter metadata configured for checkbox input.
+ */
 const bool = (name: string, label: string, defaultValue: boolean): MeshGeometryParameterDefinition => ({name, label, type: "boolean", defaultValue});
 
 /**
@@ -64,6 +114,17 @@ export const MESH_GEOMETRY_PARAMETER_DEFINITIONS: Record<string, MeshGeometryPar
 	torusKnot: [num("radius", "Radius", 0.4), num("tube", "Tube", 0.15), int("tubularSegments", "Tubular Segments", 80, 3), int("radialSegments", "Radial Segments", 12, 3), int("p", "P", 2, 1), int("q", "Q", 3, 1)],
 };
 
+/**
+ * Normalize a partial parameter set for a mesh type.
+ *
+ * Missing values are filled from the parameter definitions, invalid numeric
+ * values fall back to defaults, minimum values are enforced, and integer
+ * parameters are rounded.
+ *
+ * @param type - Mesh type whose definitions should be used.
+ * @param parameters - Partial or complete parameter values to normalize.
+ * @returns Complete normalized parameter values for the mesh type.
+ */
 function normalizeGeometryParameters(type: string, parameters: MeshGeometryParameters = {}): MeshGeometryParameters {
 	const definitions = MESH_GEOMETRY_PARAMETER_DEFINITIONS[type] ?? [];
 	return Object.fromEntries(definitions.map((definition) => {
@@ -79,6 +140,16 @@ function normalizeGeometryParameters(type: string, parameters: MeshGeometryParam
 	}));
 }
 
+/**
+ * Read editable geometry parameters from a mesh object.
+ *
+ * Values explicitly stored in `userData.geometryParameters` take precedence over
+ * three.js geometry `parameters`, allowing edited values to persist after the
+ * geometry is rebuilt.
+ *
+ * @param object - Object to inspect.
+ * @returns Normalized geometry parameters, or null when the object is not a supported mesh.
+ */
 export function getMeshGeometryParameters(object: Object3D): MeshGeometryParameters | null {
 	const meshType = resolveMeshType(object);
 	if (!meshType || !(object instanceof Mesh)) {
@@ -88,6 +159,13 @@ export function getMeshGeometryParameters(object: Object3D): MeshGeometryParamet
 	return normalizeGeometryParameters(meshType, object.userData.geometryParameters ?? object.geometry?.parameters ?? {});
 }
 
+/**
+ * Create a three.js geometry instance for a supported mesh type.
+ *
+ * @param type - Mesh type identifier from {@link MESH_OPTIONS}.
+ * @param parameters - Constructor parameter values for the geometry.
+ * @returns New geometry instance, or null when the mesh type is unsupported.
+ */
 function createGeometry(type: string, parameters: MeshGeometryParameters): BufferGeometry | null {
 	const params = normalizeGeometryParameters(type, parameters) as any;
 	switch (type) {
@@ -109,6 +187,17 @@ function createGeometry(type: string, parameters: MeshGeometryParameters): Buffe
 	}
 }
 
+/**
+ * Rebuild a mesh object's geometry from constructor parameters.
+ *
+ * The previous geometry is disposed to release GPU resources, and normalized
+ * values are stored on `userData.geometryParameters` for future inspector reads
+ * and persistence.
+ *
+ * @param object - Mesh object to update.
+ * @param parameters - New constructor parameter values.
+ * @returns True when the geometry was rebuilt, false for unsupported objects.
+ */
 export function updateMeshGeometry(object: Object3D, parameters: MeshGeometryParameters): boolean {
 	const meshType = resolveMeshType(object);
 	if (!meshType || !(object instanceof Mesh)) {
@@ -126,7 +215,11 @@ export function updateMeshGeometry(object: Object3D, parameters: MeshGeometryPar
 }
 
 /**
- * Resolve the mesh type of an object based on its geometry or user data.
+ * Resolve the mesh type of an object based on its `userData.meshType` marker or
+ * the runtime three.js geometry type.
+ *
+ * @param object - Object to resolve.
+ * @returns Mesh type identifier, or null if the object is not a supported mesh.
  */
 export function resolveMeshType(object: Object3D): string | null {
 	const meshType = object.userData.meshType as string | undefined;
@@ -188,6 +281,11 @@ export function resolveMeshType(object: Object3D): string | null {
 
 /**
  * Create a mesh object of the specified type with the given material.
+ *
+ * @param type - Mesh type identifier from {@link MESH_OPTIONS}.
+ * @param material - Material to assign to the created mesh.
+ * @param parameters - Optional geometry constructor parameter overrides.
+ * @returns Mesh object of the requested type, or null when the type is unsupported.
  */
 export function createMeshObject(type: string, material: Material, parameters: MeshGeometryParameters = {}): Mesh {
 	const geometry = createGeometry(type, parameters);

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -9,16 +9,12 @@
 	"confirmDelete": "Are you sure you want to delete this item?",
 	"loading": "Loading...",
 	"noData": "No data available",
-
 	"selectAnEntity": "Select an Entity",
 	"searchEntities": "Search entities...",
-
 	"switchToOrthographic": "Switch to orthographic camera",
 	"switchToPerspective": "Switch to perspective camera",
-
 	"waiting": "Waiting...",
 	"failedToReachBackend": "Failed to reach backend on port",
-
 	"selectedObject": "Selected Object",
 	"objectName": "Name",
 	"objectNameTooltip": "Display name for the selected object.",
@@ -52,7 +48,6 @@
 	"entity": "Entity",
 	"objectLocked": "This object is locked and cannot be edited.",
 	"selectObjectPrompt": "Select an object from the tree to edit its properties.",
-
 	"collapseSidebar": "Collapse sidebar",
 	"controls": "Controls",
 	"translateObject": "Translate object",
@@ -89,14 +84,14 @@
 	"addDoor": "Add door to selected wall",
 	"addWindow": "Add window to selected wall",
 	"exitWallTools": "Exit wall tools",
-
 	"hintMeasureDistance": "Double-click on 2 points to measure distance",
 	"hintMeasureAngle": "Double-click on 3 points to measure angle",
 	"hintWallEnd": "Click to set the end point of the wall",
 	"hintWallStart": "Click to set the start point of the wall",
 	"hintAddDoor": "Select a wall, then click to add a door",
 	"hintAddWindow": "Select a wall, then click to add a window",
-
 	"configuration": "Configuration",
-	"address": "Address"
+	"address": "Address",
+	"geometry": "Geometry",
+	"geometryParameterTooltip": "Rebuilds the mesh with this three.js geometry constructor parameter."
 }

--- a/frontend/src/service/space-sync.ts
+++ b/frontend/src/service/space-sync.ts
@@ -1,8 +1,8 @@
 import type {Object3D} from "three";
-import {BoxGeometry, Group, Mesh, MeshStandardMaterial} from "three";
+import {Group, Mesh, MeshStandardMaterial} from "three";
 
 import type {DT3DTree} from "../components/object-tree/object-tree.js";
-import {createMeshObject} from "../editor/mesh-handler.js";
+import {createMeshObject, getMeshGeometryParameters} from "../editor/mesh-handler.js";
 import type {SceneManager} from "../editor/scene.js";
 import {DTObject} from "../objects/dt-object.js";
 import {EntityObject} from "../objects/entity-object.js";
@@ -205,7 +205,8 @@ export class SpaceSync {
 				}
 			} else {
 				const material = new MeshStandardMaterial({color});
-				object = createMeshObject(meshType, material);
+				const geometryParameters = data.geometryParameters as Record<string, number | boolean> | undefined;
+				object = createMeshObject(meshType, material, geometryParameters);
 			}
 			if (object) {
 				object.userData.meshType = meshType;
@@ -317,13 +318,11 @@ export class SpaceSync {
 					data.color = material.color.getHexString();
 				}
 
-				if (object instanceof Mesh && object.geometry instanceof BoxGeometry) {
-					const params = object.geometry.parameters as { width?: number; height?: number; depth?: number };
-					data.dimensions = {
-						width: params?.width,
-						height: params?.height,
-						depth: params?.depth,
-					};
+				if (object instanceof Mesh) {
+					const geometryParameters = getMeshGeometryParameters(object);
+					if (geometryParameters) {
+						data.geometryParameters = geometryParameters;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Motivation
- Allow users to edit mesh constructor parameters (radius, segments, width/height/depth, etc.) for built-in three.js geometries directly from the object inspector so geometry can be tweaked without re-exporting models.

### Description
- Added `MESH_GEOMETRY_PARAMETER_DEFINITIONS` plus helper types and functions (`normalizeGeometryParameters`, `createGeometry`, `getMeshGeometryParameters`, `updateMeshGeometry`) in `frontend/src/editor/mesh-handler.ts` to describe supported three.js geometry constructor parameters and to build/update geometries from parameter sets.
- Updated `createMeshObject` to accept optional `parameters` and persist `userData.geometryParameters` so new meshes can be created with custom constructor values.
- Exposed editable geometry parameter controls in the inspector by adding `getGeometryFields` and handling `geometry.<param>` changes in `frontend/src/components/object-inspector/object-inspector.ts`, which rebuild the mesh via `updateMeshGeometry` and respect object `locked` state.
- Extended the dynamic form to support per-field `step` and `min` metadata by adding `step`/`min` to `DynamicFormField` and wiring them through to numeric inputs in `frontend/src/components/dynamic-form/dynamic-form.ts` so integer-like parameters behave correctly.
- Persisted edited geometry parameters to the backend payload and restored them on load by including `geometryParameters` in `frontend/src/service/space-sync.ts` and reading them back when recreating meshes.
- Added localization strings for the new inspector section: `geometry` and `geometryParameterTooltip` in `frontend/src/locale/en.json`.

### Testing
- Ran `npm run build` in `frontend` and the build completed successfully (`vite build` produced the production bundle). 
- Ran targeted linter on changed files with `npx eslint src/components/dynamic-form/dynamic-form.ts src/components/object-inspector/object-inspector.ts src/editor/mesh-handler.ts src/service/space-sync.ts` which completed for the modified files.
- Ran repository lint (`npm run lint`) and observed pre-existing repository-wide lint issues unrelated to these changes (generated `dist` files and global config), which did not block committing the feature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3804f1404483328f8e8166e70b50ba)