### PR TITLE
Add image texture editing for meshes (drag-drop + inspector)

### DIFF
--- a/frontend/src/components/card.ts
+++ b/frontend/src/components/card.ts
@@ -23,6 +23,7 @@ import {FBXLoader} from "three/examples/jsm/loaders/FBXLoader.js";
 import {GLTFLoader} from "three/examples/jsm/loaders/GLTFLoader.js";
 import {OBJLoader} from "three/examples/jsm/loaders/OBJLoader.js";
 
+import {applyImageTextureToMesh, findMesh} from "../editor/material-texture.js";
 import {MeasurementManager} from "../editor/measurements.js";
 import {createMeshObject, resolveMeshType} from "../editor/mesh-handler.js";
 import {RendererManager} from "../editor/renderer.js";
@@ -428,6 +429,24 @@ export class DT3DCard extends LitElement {
 		this.tree.updateTreeDiff(this.space);
 
 		void this.spaceSync?.syncObjectHierarchyCreate(clone);
+	}
+
+	private async handleTextureDrop(event: DragEvent): Promise<void> {
+		event.preventDefault();
+		const file = Array.from(event.dataTransfer?.files ?? []).find((candidate) => candidate.type.startsWith("image/"));
+		if (!file) {
+			return;
+		}
+
+		const {intersection} = this.pickObjectFromEvent(event as MouseEvent);
+		const mesh = findMesh(intersection?.object ?? null);
+		if (!mesh) {
+			return;
+		}
+
+		await applyImageTextureToMesh(mesh, file);
+		this.tree.refreshSelectedObject();
+		void this.spaceSync?.syncObjectUpdate(mesh);
 	}
 
 	/**
@@ -975,6 +994,14 @@ export class DT3DCard extends LitElement {
 
 		this.canvas.addEventListener("click", (event: MouseEvent) => {
 			this.handleCanvasClick(event);
+		});
+
+		this.canvas.addEventListener("dragover", (event: DragEvent) => {
+			event.preventDefault();
+		});
+
+		this.canvas.addEventListener("drop", (event: DragEvent) => {
+			void this.handleTextureDrop(event);
 		});
 
 		this.canvas.addEventListener("mousemove", (event: MouseEvent) => {

--- a/frontend/src/components/dynamic-form/dynamic-form.ts
+++ b/frontend/src/components/dynamic-form/dynamic-form.ts
@@ -12,7 +12,8 @@ export type DynamicFieldType =
 	| "number"
 	| "boolean"
 	| "color"
-	| "info";
+	| "info"
+	| "file";
 
 /**
  * The description of a single field to be rendered in the DynamicForm component.
@@ -226,6 +227,23 @@ export class DynamicForm extends LitElement {
 								field.type,
 								(event.target as HTMLInputElement).value,
 							)}
+						/>
+					</div>
+				`;
+			}
+			case "file": {
+				return html`
+					<div class="field">
+						<label title=${field.tooltip ?? ""}>${field.label}</label>
+						<input
+							type="file"
+							accept="image/*"
+							?disabled=${!field.editable}
+							@change=${(event: Event) => {
+								const file = (event.target as HTMLInputElement).files?.[0];
+								if (!file) return;
+								this.dispatchFieldChange(field.attribute, field.type, file);
+							}}
 						/>
 					</div>
 				`;

--- a/frontend/src/components/object-inspector/object-inspector.ts
+++ b/frontend/src/components/object-inspector/object-inspector.ts
@@ -5,6 +5,7 @@ import {customElement, property} from "lit/decorators.js";
 import type {Object3D} from "three";
 import {Color, Mesh} from "three";
 
+import {applyImageTextureToMesh, clearMeshTexture, findMesh} from "../../editor/material-texture.js";
 import {getMeshGeometryParameters, MESH_GEOMETRY_PARAMETER_DEFINITIONS, resolveMeshType, updateMeshGeometry} from "../../editor/mesh-handler.js";
 import {localManager} from "../../locale/locale.js";
 import {DTObject} from "../../objects/dt-object.js";
@@ -118,6 +119,22 @@ export class DT3DObjectInspector extends LitElement {
 				return;
 			}
 			this.selectedObject.material.color.set(colorValue);
+		} else if (attribute === "material.texture") {
+			const mesh = findMesh(this.selectedObject);
+			if (!mesh || !(value instanceof File)) {
+				return;
+			}
+			void applyImageTextureToMesh(mesh, value).then(() => {
+				this.dispatchUpdated();
+				this.requestUpdate();
+			});
+			return;
+		} else if (attribute === "material.clearTexture") {
+			const mesh = findMesh(this.selectedObject);
+			if (!mesh || value !== true) {
+				return;
+			}
+			clearMeshTexture(mesh);
 		} else if (attribute === "height" || attribute === "thickness") {
 			if (!this.isWallObject(this.selectedObject)) {
 				return;
@@ -225,6 +242,27 @@ export class DT3DObjectInspector extends LitElement {
 				editable: !locked,
 				enabled: true,
 			});
+		}
+
+		if (findMesh(this.selectedObject)) {
+			fields.push(
+				{
+					label: localManager.get("materialTexture"),
+					attribute: "material.texture",
+					type: "file",
+					tooltip: localManager.get("materialTextureTooltip"),
+					editable: !locked,
+					enabled: true,
+				},
+				{
+					label: localManager.get("clearMaterialTexture"),
+					attribute: "material.clearTexture",
+					type: "boolean",
+					tooltip: localManager.get("clearMaterialTextureTooltip"),
+					editable: !locked,
+					enabled: true,
+				},
+			);
 		}
 
 		return fields;

--- a/frontend/src/editor/material-texture.ts
+++ b/frontend/src/editor/material-texture.ts
@@ -1,0 +1,98 @@
+import type {Material, Object3D, Texture} from "three";
+import {Mesh, MeshStandardMaterial, TextureLoader} from "three";
+
+export type TexturedMaterialData = {
+	textureDataUrl?: string;
+	textureName?: string;
+};
+
+const imageFilePattern = /^image\//;
+
+export function isImageFile(file: File): boolean {
+	return imageFilePattern.test(file.type);
+}
+
+export function readFileAsDataUrl(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.addEventListener("load", () => {
+			if (typeof reader.result === "string") {
+				resolve(reader.result);
+			} else {
+				reject(new Error("Unable to read image file."));
+			}
+		});
+		reader.addEventListener("error", () => reject(reader.error ?? new Error("Unable to read image file.")));
+		reader.readAsDataURL(file);
+	});
+}
+
+export function loadTexture(dataUrl: string): Promise<Texture> {
+	return new Promise((resolve, reject) => {
+		new TextureLoader().load(dataUrl, resolve, undefined, reject);
+	});
+}
+
+function disposeMaterialMap(material: Material): void {
+	const map = (material as any).map as Texture | null | undefined;
+	if (map) {
+		map.dispose();
+	}
+}
+
+export async function applyImageTextureToMesh(mesh: Mesh, file: File): Promise<void> {
+	if (!isImageFile(file)) {
+		throw new Error("Only image files can be used as mesh textures.");
+	}
+
+	const dataUrl = await readFileAsDataUrl(file);
+	await applyTextureDataUrlToMesh(mesh, dataUrl, file.name);
+}
+
+export async function applyTextureDataUrlToMesh(mesh: Mesh, dataUrl: string, textureName = "Texture"): Promise<void> {
+	const texture = await loadTexture(dataUrl);
+	texture.colorSpace = "srgb";
+	texture.needsUpdate = true;
+
+	const existingMaterial = Array.isArray(mesh.material) ? mesh.material[0] : mesh.material;
+	if (existingMaterial) {
+		disposeMaterialMap(existingMaterial);
+	}
+
+	const material = new MeshStandardMaterial({
+		color: existingMaterial && "color" in existingMaterial ? (existingMaterial as any).color.clone() : 0xffffff,
+		map: texture,
+	});
+
+	mesh.material = material;
+	mesh.userData.textureDataUrl = dataUrl;
+	mesh.userData.textureName = textureName;
+}
+
+export function clearMeshTexture(mesh: Mesh): void {
+	const existingMaterial = Array.isArray(mesh.material) ? mesh.material[0] : mesh.material;
+	if (existingMaterial) {
+		disposeMaterialMap(existingMaterial);
+	}
+
+	const color = existingMaterial && "color" in existingMaterial ? (existingMaterial as any).color.clone() : 0xffffff;
+	mesh.material = new MeshStandardMaterial({color});
+	delete mesh.userData.textureDataUrl;
+	delete mesh.userData.textureName;
+}
+
+export function findMesh(object: Object3D | null): Mesh | null {
+	if (!object) {
+		return null;
+	}
+	if (object instanceof Mesh) {
+		return object;
+	}
+	let mesh: Mesh | null = null;
+	object.traverse((child) => {
+		if (!mesh && child instanceof Mesh) {
+			mesh = child;
+		}
+	});
+	return mesh;
+}

--- a/frontend/src/locale/en.json
+++ b/frontend/src/locale/en.json
@@ -93,5 +93,9 @@
 	"configuration": "Configuration",
 	"address": "Address",
 	"geometry": "Geometry",
-	"geometryParameterTooltip": "Rebuilds the mesh with this three.js geometry constructor parameter."
+	"geometryParameterTooltip": "Rebuilds the mesh with this three.js geometry constructor parameter.",
+	"materialTexture": "Material Texture",
+	"materialTextureTooltip": "Choose an image file to apply as a new material texture.",
+	"clearMaterialTexture": "Clear Texture",
+	"clearMaterialTextureTooltip": "Remove the current image texture from the material."
 }

--- a/frontend/src/service/space-sync.ts
+++ b/frontend/src/service/space-sync.ts
@@ -2,6 +2,7 @@ import type {Object3D} from "three";
 import {Group, Mesh, MeshStandardMaterial} from "three";
 
 import type {DT3DTree} from "../components/object-tree/object-tree.js";
+import {applyTextureDataUrlToMesh} from "../editor/material-texture.js";
 import {createMeshObject, getMeshGeometryParameters} from "../editor/mesh-handler.js";
 import type {SceneManager} from "../editor/scene.js";
 import {DTObject} from "../objects/dt-object.js";
@@ -232,6 +233,10 @@ export class SpaceSync {
 		object.name = instance.name || object.name;
 		this.applyObjectTransform(object, data);
 
+		if (object instanceof Mesh && typeof data.textureDataUrl === "string") {
+			void applyTextureDataUrlToMesh(object, data.textureDataUrl, typeof data.textureName === "string" ? data.textureName : "Texture");
+		}
+
 		if (object instanceof DTObject && typeof data.locked === "boolean") {
 			object.locked = data.locked;
 		}
@@ -316,6 +321,11 @@ export class SpaceSync {
 				const material = (object as Mesh).material as any;
 				if (material?.color?.getHexString) {
 					data.color = material.color.getHexString();
+				}
+
+				if (typeof object.userData.textureDataUrl === "string") {
+					data.textureDataUrl = object.userData.textureDataUrl;
+					data.textureName = object.userData.textureName;
 				}
 
 				if (object instanceof Mesh) {


### PR DESCRIPTION
### Motivation
- Enable users to apply image files as textures to 3D meshes by dragging images onto the canvas and to manage those textures from the object inspector. 
- Persist texture data so materials can be restored when spaces/objects are loaded.

### Description
- Added a shared helper module `frontend/src/editor/material-texture.ts` providing `isImageFile`, `readFileAsDataUrl`, `loadTexture`, `applyImageTextureToMesh`, `applyTextureDataUrlToMesh`, `clearMeshTexture`, and `findMesh` to read images and create textured `MeshStandardMaterial` instances. 
- Added canvas drag-and-drop handling in `DT3DCard` (`handleTextureDrop`) and registered `dragover`/`drop` listeners so dropped images are applied to the mesh under the cursor and the change is synced. 
- Extended the dynamic form with a `file` field type in `frontend/src/components/dynamic-form/dynamic-form.ts` to support image selection for inspector-driven uploads. 
- Updated the object inspector `frontend/src/components/object-inspector/object-inspector.ts` to expose `material.texture` (file upload) and `material.clearTexture` controls and to apply/clear textures when those fields change. 
- Persisted texture data through `SpaceSync` by saving `userData.textureDataUrl` and `textureName` in the object payload and applying `textureDataUrl` when objects are recreated (`frontend/src/service/space-sync.ts`). 
- Added localization strings in `frontend/src/locale/en.json` for the new inspector labels/tooltips.

### Testing
- Built the frontend with `npm --prefix frontend run build`, which completed successfully. 
- Ran a targeted ESLint check on the modified source files (`npx eslint ...` against the touched files), which completed during the rollout. 
- Running the repository-wide lint (`npm --prefix frontend run lint`) surfaced pre-existing and generated-file lint issues (including `frontend/dist` artifacts) unrelated to these changes and therefore the full lint task did not pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396c5474c883329cdca8ae4c4f2729)